### PR TITLE
Minor time-stamp code changes

### DIFF
--- a/javascript/timeHandler.js
+++ b/javascript/timeHandler.js
@@ -69,7 +69,7 @@ function dateToText(date) {
 		var y = date.getYear();
 		if ( y < 1900 ) y+=1900;
 		
-		if ( secondDifference < 3*7*22*60*60 ) // with 19 days, 6 hours
+		if ( secondDifference < 3*7*22*60*60 ) // within 19 days, 6 hours
 			return a+" "+d+" "+b; // Day Day# Month
 		else
 			return d+" "+b+" "+y; // Day# Month Year


### PR DESCRIPTION
In function dateToText(date):
-Removed some redundant code in 24-hour to AM/PM conversion
-Fixed to always add leading zero for single digit hour

Added a question regarding lines 59 and 71:
// YW: should 22 be replaced with 24?
