### PR TITLE
live game start time text

### DIFF
--- a/locales/lookup_examples.txt
+++ b/locales/lookup_examples.txt
@@ -9,6 +9,8 @@
 '%s hours, %s minutes' => '%s ore, %s minuti',
 '%s minutes' => '%s minuti',
 '%s minutes, %s seconds' => '%s minuti, %s secondi',
+'%s players joined; game will start at the scheduled time' => '%s giocatori entrato; partita inizierà al tempo previsto'
+'%s players joined; game will start on next process cycle' => '%s giocatori entrato; gioco avrà inizio di lavorazione successiva il ciclo'
 '%s replies' => '%s risposte',
 '%s supply-centers, %s units' => '%s centri, %s unitÃ ',
 '%s units' => '%s unitÃ ',
@@ -293,6 +295,7 @@
 'Okay, now that we know you\'re a human we need to check that you have a real e-mail address.' => 'Bene, ora che sappiamo che sei un umano dobbiamo controllare che tu abbia un indirizzo e-mail valido.',
 'Once the reason for the period of no processing is known, and it\'s safe to reenable
 					game processing, the last process time can be reset here' => 'Una volta che il motivo dello stop alla risoluzione degli ordini sia chiaro e che far ripartire l\'aggiornamento delle partite sia considerato sicuro, da qui si puÃ² resettare l\'ultima fase di aggiornamento',
+'One or more players need to complete their orders before this strict/tournament game can go on' => 'Uno o più giocatori devono completare i loro ordini prima questo gioco rigida / torneo può continuare'
 'Online' => 'Connesso',
 'Open' => 'Aperte',
 'Open %s chatbox tab\"' => 'Open %s chatbox tab\"',
@@ -426,6 +429,8 @@
 'The current page; click to refresh' => 'La pagina corrente; clicca per aggiornare',
 'The e-mail may take a couple of minutes to arrive; if it doesn\'t appear check your spam inbox.' => 'L\'invio dell\'email potrebbe impiegare un paio di minuti; se non appare nella vostra casella di posta, controllate la vostra sezione di spam.',
 'The full game listing search panel' => 'Il pannello di ricerca con la lista di tutte le partite',
+'The game will start at the scheduled time even if all %s players have joined.' => 'Il gioco inizierà al tempo previsto, anche quando tutti e %s i giocatori si sono uniti.'
+'The game will start when all %s players have joined.' => 'Il gioco inizierà quando tutti e %s i giocatori si sono uniti.'
 'The map for the %s Variant' => 'La mappa della variante %s',
 'The password you entered is incorrect.' => 'La password inserita Ã¨ errata.',
 'The results of a set of automated tests which show the webDiplomacy\'s compliance with the official Diplomacy rules.' => 'Il risultato di un set di test automatici che mostra la conformitÃ  di webDiplomacy con le regole ufficiali di Diplomacy.',
@@ -527,9 +532,13 @@
 'fail' => 'fallito',
 'fast' => 'veloce',
 'game' => 'partita',
+'game started' => 'partita iniziata',
+'game starting' => 'gioco di partenza'
+'game starting soon' => 'gioco di partenza presto'
 'it\'s a guest account, used by unregistered people to view the server without interacting.' => 'Ã¨ un account \"ospite\", usato da persone non registrate per accedere al server senza interagire.',
 'live' => 'live',
 'normal' => 'normale',
+'not a member' => 'non un membro',
 'replies' => 'risposte',
 'reply' => 'rispondi',
 'slow' => 'lenta',

--- a/objects/game.php
+++ b/objects/game.php
@@ -423,6 +423,15 @@ class Game
 	}
 
 	/**
+	 * Check whether this game will be considered a "live" game.
+	 * @return true if phase minutes are less than 60.
+	 **/
+	function isLiveGame()
+	{
+		return $this->phaseMinutes < 60;
+	}
+
+	/**
 	 * Return the next process time in textual format, in terms of time remaining
 	 *
 	 * @return string
@@ -482,7 +491,7 @@ class Game
 			!( $this->missingPlayerPolicy=='Strict'&&!$this->Members->isComplete() ) && (
 				time() >= $this->processTime
 				|| ( ($this->phase!='Pre-game' && $this->Members->isReady() )
-					|| ($this->phase=='Pre-game' && count($this->Members->ByID)==count($this->Variant->countries) && $this->phaseMinutes>30 ) )
+					|| ($this->phase=='Pre-game' && count($this->Members->ByID)==count($this->Variant->countries) && !($this->isLiveGame()) ) )
 				)
 			)
 			return true;

--- a/objects/members.php
+++ b/objects/members.php
@@ -274,8 +274,9 @@ class Members
 			return l_t("not a member");
 		elseif($this->Game->phase != 'Pre-game')
 			return l_t("game started");
-		elseif(count($this->ByID)==count($this->Game->Variant->countries))
-			return l_t("game starting");
+		elseif(count($this->ByID)==count($this->Game->Variant->countries) &&
+		       time() + 30*60 > $this->Game->processTime)
+			return l_t("game starting soon");
 		elseif(time()>$this->Game->processTime)
 			return l_t("game starting");
 		elseif ( $Misc->Panic )


### PR DESCRIPTION
gamepanel/game.php - gameNoticeBar() - check isLiveGame() for different pre-game text.
gamepanel/game.php - gameHoursPerPhase() - call isLiveGame() instead of phase minutes < 60.
gamepanel/game.php - joinBar() - check isLiveGame() for different text on join confirmation box.
locales/lookup_examples.txt - Added new translations
objects/game.php - isLiveGame() - New function that returns true if phase minutes is less than 60.
objects/game.php - needProcess() - Call !isLiveGame() instead of checking phase minutes > 30.
objects/members.php - cantLeaveReason() - Allow leaving of a full game up to 30 minutes before scheduled start.

These changes add information about when a game (live vs. non-live) will start on the Join popup confirmation box and also corrects the text at the top of a live game when all players have joined but the start time has not yet been reached.

They also allow players to leave a live game that has not started yet, and will not start for at least 30 minutes, but has the full compliment of players.  Previously you could not leave a non-started live game once it reached full capacity no matter the scheduled start time.
