### PR TITLE
Add Notes tab for all press types and read-only Global tab for nopress

### DIFF
--- a/board.php
+++ b/board.php
@@ -233,7 +233,7 @@ if( isset($Member) && $Member->status == 'Playing' && $Game->phase!='Finished' )
 	}
 }
 
-if ( 'Pre-game' != $Game->phase && $Game->pressType!='NoPress' && ( isset($Member) || $User->type['Moderator'] ) )
+if ( 'Pre-game' != $Game->phase && ( isset($Member) || $User->type['Moderator'] ) )
 {
 	$CB = $Game->Variant->Chatbox();
 

--- a/board/chatbox.php
+++ b/board/chatbox.php
@@ -61,8 +61,8 @@ class Chatbox
 		if ( $msgCountryID<=0 || $msgCountryID>count($Game->Variant->countries) )
 			$msgCountryID = 0;
 
-		// enforce Global tab when its not Regular press game.
-		if ( $Game->pressType != 'Regular' )
+		// Enforce Global and Notes tabs when its not Regular press game.
+		if ( $Game->pressType != 'Regular' && !(isset($Member) && $Member->countryID == $msgCountryID) )
 			$msgCountryID = 0;
 
 		$_SESSION[$Game->id.'_msgCountryID'] = $msgCountryID;
@@ -92,9 +92,12 @@ class Chatbox
 		{
 			$newmessage = trim($_REQUEST['newmessage']);
 
-			if( isset($Member)
-					&& $Game->pressType != 'NoPress'
-					&& ($Game->pressType != 'PublicPressOnly' || $msgCountryID == 0) )
+			if ( isset($Member) &&
+			     ( $Game->pressType == 'Regular' ||                                        // All tabs allowed for Regular
+			       $Member->countryID == $msgCountryID ||                                  // Notes tab always allowed
+			       ( $msgCountryID == 0 &&                                                 // Global tab allowed for...
+			         ( $Game->pressType == 'PublicPressOnly' ||                            // public press and
+			           ( $Game->pressType == 'NoPress' && $Game->phase == 'Finished' ))))) // finished nopress.
 			{
 				$sendingToMuted = false;
 
@@ -149,7 +152,7 @@ class Chatbox
 				$memList[]=$Game->Members->ByCountryID[$countryID]->memberNameCountry();
 			$chatbox .= '<div class="chatboxMembersList">'.implode(', ',$memList).'</div>';
 		}
-		else
+		else if (!isset($Member) || $Member->countryID != $msgCountryID)
 		{
 			$chatbox .= $Game->Members->ByCountryID[$msgCountryID]->memberBar();
 		}
@@ -174,7 +177,13 @@ class Chatbox
 
 		$chatbox .= '</TABLE></DIV>';
 
-		if ( ( isset($Member) && $Game->pressType != 'NoPress' ) || $User->type['Moderator'] )
+		if ( ( $User->type['Moderator'] && $msgCountryID == 0 ) ||
+		     ( isset($Member) &&
+		       ( $Game->pressType == 'Regular' ||                                         // All tabs allowed for Regular
+		         $Member->countryID == $msgCountryID ||                                   // Notes tab always allowed
+		         ( $msgCountryID == 0 &&                                                  // Global tab allowed for...
+		           ( $Game->pressType == 'PublicPressOnly' ||                             // public press and
+		             ( $Game->pressType == 'NoPress' && $Game->phase == 'Finished' )))))) // finished nopress.
 		{
 			$chatbox .= '<DIV class="chatbox"><TABLE>
 					<TR class="barAlt2">
@@ -201,7 +210,7 @@ class Chatbox
 		if ( isset($_REQUEST['msgCountryID']) )
 			libHTML::$footerScript[] = '
 				var sb = $("sendbox");
-				if( !Object.isUndefined(sb) ) {
+				if( sb != null && !Object.isUndefined(sb) ) {
 					$("sendbox").focus();
 				}
 			';
@@ -223,25 +232,26 @@ class Chatbox
 
 		for( $countryID=0; $countryID<=count($Game->Variant->countries); $countryID++)
 		{
-			// leave Global tab open even if its NoPress game..
-			if ($Game->pressType != 'Regular' && $countryID != 0 ) continue;
-			if ( $countryID == $Member->countryID ) continue;
+			// Do not allow country specific tabs for restricted press games.
+			if ($Game->pressType != 'Regular' && $countryID != 0 && $countryID != $Member->countryID ) continue;
 
 			$tabs .= ' <a href="./board.php?gameID='.$Game->id.'&amp;msgCountryID='.$countryID.'&amp;rand='.rand(1,100000).'#chatboxanchor" '.
 				'class="country'.$countryID.' '.( $msgCountryID == $countryID ? 'current"'
 					: '" title="'.l_t('Open %s chatbox tab"',( $countryID == 0 ? 'the global' : $this->countryName($countryID)."'s" )) ).'>';
 
-			if(isset($Game->Members->ByCountryID[$countryID]))
-				$tabs .= $Game->Members->ByCountryID[$countryID]->memberCountryName();
-			else
-				$tabs .= l_t('Global');
-
-			if(isset($Game->Members->ByCountryID[$countryID]))
-
-			if ( isset($Game->Members->ByCountryID[$countryID]) )
+			if ( $countryID == $Member->countryID )
 			{
+				$tabs .= l_t('Notes');
+			}
+			elseif(isset($Game->Members->ByCountryID[$countryID]))
+			{
+				$tabs .= $Game->Members->ByCountryID[$countryID]->memberCountryName();
 				if ( $Game->Members->ByCountryID[$countryID]->online && !$Game->Members->ByCountryID[$countryID]->isNameHidden() )
 					$tabs .= ' '.libHTML::loggedOn($Game->Members->ByCountryID[$countryID]->userID);
+			}
+			else
+			{
+				$tabs .= l_t('Global');
 			}
 
 			if ( $msgCountryID != $countryID and in_array($countryID, $Member->newMessagesFrom) )

--- a/lib/gamemessage.php
+++ b/lib/gamemessage.php
@@ -72,7 +72,10 @@ class libGameMessage
 						'".$message."',
 						".time().")");
 
-		libGameMessage::notify($toCountryID, $fromCountryID);
+		if ($toCountryID != $fromCountryID)
+		{
+			libGameMessage::notify($toCountryID, $fromCountryID);
+		}
 	}
 
 	/**


### PR DESCRIPTION
I've made these changes on the beta site (but not staged or committed) so you can see how it functions there.

Add "Notes" tab to list of output tabs using country's own country id.
Show Global tab for gunboat games, no sendbox for non-finished games.

board/chatbox.php - findTab() - allow $msgCountryID to be set to the Notes value for all press types.

board/chatbox.php - postMessage() - allow posting to Notes tab for all press types.
board/chatbox.php - postMessage() - allow posting to Global tab for Finished nopress games.

board/chatbox.php - output() - don't show the member bar on the Notes tab.
board/chatbox.php - output() -
previous functionality:
*for moderator, show sendbox regardless of tab (except reaching non-global tab requires url manipulation.)
*for member, show sendbox if regular or public press, regardless of tab.
new functionality:
*for moderator, show sendbox on global tab only
*for member, show sendbox if regular press on any tab, or Notes tab,
*or public press global tab, or nopress global tab on a finished game.

board/chatbox.php - outputTabs() - allow both Global and Notes tabs for non-Regular press games.  Do not block the Notes tab which is the country's own id.  Label the Notes 

tab 'Notes'.  Cleanup some redundant if statements.

lib/gamemessage.php - send() - do not call notify() if $fromCountryID is the same as $toCountryID (Notes tab).

board.php - remove restriction on showing Chatbox on NoPress games.
