### PR TITLE
Sort Members in anon-games by countryID

### DIFF
--- a/objects/members.php
+++ b/objects/members.php
@@ -200,7 +200,8 @@ class Members
 			INNER JOIN wD_Users u ON ( m.userID = u.id )
 			LEFT JOIN wD_Sessions s ON ( u.id = s.userID )
 			WHERE m.gameID = ".$this->Game->id."
-			ORDER BY m.status ASC, m.supplyCenterNo DESC, u.points DESC".
+			ORDER BY m.status ASC, m.supplyCenterNo DESC, ".
+			($this->Game->anon=='Yes' ? "m.countryID ASC" : "u.points DESC" ).
 			$this->Game->lockMode
 			);
 


### PR DESCRIPTION
Does fix a problem in anon games.
It was possible to guess the user because if both players have the same SC count it's sorted by DPoints.
Changed this, so it's sorted in anon-games by countryID. There is no change for non-anon games.
