### PR TITLE
Updated error message when support move is used instead of convoy.

### DIFF
--- a/board/orders/order.php
+++ b/board/orders/order.php
@@ -326,10 +326,17 @@ abstract class userOrder extends order
 			if( $this->{$paramName.'Check'}() )
 				return true;
 			else
-			{
-				$this->error = l_t("Parameter '%s' set to invalid value '%s'",$paramName,$this->{$paramName});
-				$this->setStatus('Invalid');
-				$this->followingAreInvalid=true;
+            {
+                if( $paramName == "fromTerrID" ) 
+                {
+                    $this->error = l_t("Invalid order. Did you mean convoy instead of support move?");
+                } 
+                else 
+                {
+                    $this->error = l_t("Parameter '%s' set to invalid value '%s'",$paramName,$this->{$paramName});
+                }
+                $this->setStatus('Invalid');
+                $this->followingAreInvalid=true;
 
 				return false;
 			}


### PR DESCRIPTION
Improved error message for the situation described [here](http://webdiplomacy.net/forum.php?viewthread=1148860). This assumes that an invalid fromTerrID is due to the support move instead of convoy situation.

Note: There's no entry in the translation tables for the old error message, so I didn't include an updated translation for this new message (also, I don't speak Italian).
