### PR TITLE
A mechanism for user options, and client side colourblind fix

### DIFF
--- a/install/1.37-1.38/update.sql
+++ b/install/1.37-1.38/update.sql
@@ -1,9 +1,11 @@
-CREATE TABLE `wD_WatchedGames` (
-		  `userID` mediumint(8) unsigned NOT NULL,		
-		  `gameID` mediumint(8) unsigned NOT NULL,		
-		  KEY `gid` (`gameID`),		
-		  KEY `uid` (`userID`)		
-	) ENGINE=InnoDB DEFAULT CHARSET=utf8;		
-		
-		
--UPDATE `wD_Misc` SET `value` = '138' WHERE `name` = 'Version';
+ CREATE TABLE `wD_WatchedGames` (
+	  `userID` mediumint(8) unsigned NOT NULL,
+	  `gameID` mediumint(8) unsigned NOT NULL,
+	  KEY `gid` (`gameID`),
+	  KEY `uid` (`userID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+ALTER TABLE wD_Games ADD `minimumReliabilityRating` tinyint(3) unsigned NOT NULL DEFAULT '0';
+ALTER TABLE wD_Backup_Games ADD `minimumReliabilityRating` tinyint(3) unsigned NOT NULL DEFAULT '0';
+
+UPDATE `wD_Misc` SET `value` = '138' WHERE `name` = 'Version';


### PR DESCRIPTION
Adds `objects/useroptions.php`, an object for handling user options. User options are stored in their own table, which is only populated when users save options (so it is lazily created for existing members). They are loaded when a `User` object is created. In addition to being part of the user object, options are also exposed to the client through `useroptions.php`, which produces a json object that describes a user's preferences for use in javascript.

The colorblindness fix is applied client side, depending on the user's options. It is triggered when the map changes, and replaces the map image with an appropriately adjusted version. Additionally, press is displayed with the country's name at the start of the message. Thanks to @Sleepcap for the suggestions and inspiration of this feature.

Additionally, the options contain an option to always hide the move arrows on the board, and to hide the new live game announcement on the home page.

Feedback welcome.