### PR TITLE
Fix for #149: Expose pot type in small gamepanel view on home page

### DIFF
--- a/gamepanel/gamehome.php
+++ b/gamepanel/gamehome.php
@@ -150,7 +150,23 @@ class panelGameHome extends panelGameBoard
 	 */
 	function pot()
 	{
-		return $this->pot.' '.libHTML::points().' '.$this->potTypeAbbr;
+		return $this->pot.' '.libHTML::points().' '.$this->potTypeAbbr();
+	}
+
+	/**
+	* Pot type abbreviation
+	* @return string
+	*/
+	function potTypeAbbr()
+	{
+		switch($this->potType) {
+			case 'Winner-takes-all':
+				return 'WTA';
+			case 'Points-per-supply-center':
+				return 'PPSC';
+			default:
+				return '';
+		}
 	}
 
 	/**

--- a/gamepanel/gamehome.php
+++ b/gamepanel/gamehome.php
@@ -150,7 +150,7 @@ class panelGameHome extends panelGameBoard
 	 */
 	function pot()
 	{
-		return $this->pot.' '.libHTML::points();
+		return $this->pot.' '.libHTML::points().' '.$this->potTypeAbbr;
 	}
 
 	/**

--- a/objects/game.php
+++ b/objects/game.php
@@ -168,12 +168,6 @@ class Game
 	public $potType;
 
 	/**
-	 * Abbreviation for pot type
-	 * @var string
-	 */
-	public $potTypeAbbr;
-
-	/**
 	 * draw-votes-public/draw-votes-hidden
 	 * @var string
 	 */
@@ -328,18 +322,6 @@ class Game
 
 		// If there is a password the game is private
 		$this->private = isset($this->password);
-
-		// pot type abbreviations
-		switch($this->potType) {
-			case 'Points-per-supply-center':
-				$this->potTypeAbbr = 'PPSC';
-				break;
-			case 'Winner-takes-all':
-				$this->potTypeAbbr = 'WTA';
-				break;
-			default:
-				$this->potTypeAbbr = '';
-		}
 
 		$this->Variant = $GLOBALS['Variants'][$this->variantID];
 	}                         

--- a/objects/game.php
+++ b/objects/game.php
@@ -168,6 +168,12 @@ class Game
 	public $potType;
 
 	/**
+	 * Abbreviation for pot type
+	 * @var string
+	 */
+	public $potTypeAbbr;
+
+	/**
 	 * draw-votes-public/draw-votes-hidden
 	 * @var string
 	 */
@@ -322,6 +328,18 @@ class Game
 
 		// If there is a password the game is private
 		$this->private = isset($this->password);
+
+		// pot type abbreviations
+		switch($this->potType) {
+			case 'Points-per-supply-center':
+				$this->potTypeAbbr = 'PPSC';
+				break;
+			case 'Winner-takes-all':
+				$this->potTypeAbbr = 'WTA';
+				break;
+			default:
+				$this->potTypeAbbr = '';
+		}
 
 		$this->Variant = $GLOBALS['Variants'][$this->variantID];
 	}                         


### PR DESCRIPTION
Decided to just use a switch statement for generating the abbreviations for the pot type rather than make database updates.