### PR TITLE
Forum reply redirects to eliminate double post bug

### DIFF
--- a/forum.php
+++ b/forum.php
@@ -230,8 +230,7 @@ AND ($_REQUEST['newmessage'] != "") ) {
 						$_SESSION['lastPostTime']=time();
 						$_SESSION['lastPostType']='ThreadReply';
 
-						$messageproblem=l_t("Reply posted sucessfully.");
-						$new['message']=""; $new['subject']="";
+						header("Location: " . $_SERVER['REQUEST_URI'] . '&reply=success');
 					}
 					catch(Exception $e)
 					{
@@ -265,6 +264,11 @@ else
 }
 
 $_SESSION['viewthread'] = $viewthread;
+
+if (isset($_REQUEST['reply']) && $_REQUEST['reply'] == 'success') {
+	$messageproblem=l_t("Reply posted sucessfully.");
+	$new['message']=""; $new['subject']=""; $new['sendtothread']=$viewthread;
+}
 
 libHTML::starthtml();
 


### PR DESCRIPTION
This logic will force successful forum replies to issue a redirect after successful submission with "reply=success" as a url parameter (this parameter enables the "Reply posted successfully" message to show up).  Any refreshes of the page will have this success message stay intact, but no messages will be reposted.