### PR TITLE
Bugfix #201

### DIFF
--- a/board.php
+++ b/board.php
@@ -246,7 +246,6 @@ if( isset($Member) && $Member->status == 'Playing' && $Game->phase!='Finished' )
 	}
 }
 
-//if ( 'Pre-game' != $Game->phase && ( isset($Member) || $User->type['Moderator'] ) )
 if ( 'Pre-game' != $Game->phase )
 {
 	$CB = $Game->Variant->Chatbox();

--- a/board.php
+++ b/board.php
@@ -246,7 +246,8 @@ if( isset($Member) && $Member->status == 'Playing' && $Game->phase!='Finished' )
 	}
 }
 
-if ( 'Pre-game' != $Game->phase && ( isset($Member) || $User->type['Moderator'] ) )
+//if ( 'Pre-game' != $Game->phase && ( isset($Member) || $User->type['Moderator'] ) )
+if ( 'Pre-game' != $Game->phase )
 {
 	$CB = $Game->Variant->Chatbox();
 


### PR DESCRIPTION
The chat panel is now visible to every visitor of the game, once the game started.

**Test cases, checked and passed**
* Tested under Firefox
* Created a game with no chat restrictions.
** Mods/Admins see the global tab and are able to write messages.
** Participants see all tabs and are able to write in every tab.
** Spectators (or Observers, they don't have to select "Spectate") can see the global tab but nothing else. They are not able to write in the global tab.

* Created a game with no ingame-messaging
** Mods/Admins are able to see the global tab and write in it.
** Participants are able to see the global and notes tab, but can only write in the notes tab.
** Spectators are able to see the global tab

**Test cases not checked**
* A game with global press only

**Possibly unexpected/unwanted behaviour**
* In games with no chat, spectators will still be able to see the Global Tab (although it will mostly be empty)
* Users that are not logged on are also able to see every chat panel as well
* Before the game starts no one is able to see the chatbox (might be confusing for users that are only spectating?)