### PR TITLE
Display message when leaving page with unsaved orders

### DIFF
--- a/javascript/orders/form.js
+++ b/javascript/orders/form.js
@@ -177,11 +177,13 @@ function OrdersHTMLFormClass() {
 			if( MyOrders.pluck('isChanged').any(function(c){return c;}) )
 			{
 				this.ordersChanged=true;
+				window.ordersChanged = true;
 				this.buttonOn('UpdateButton');
 			}
 			else
 			{
 				this.ordersChanged=false;
+				window.ordersChanged=false;
 				this.buttonOff('UpdateButton');
 			}
 	
@@ -195,3 +197,29 @@ function OrdersHTMLFormClass() {
 function loadOrdersForm() {
 	OrdersHTML = new OrdersHTMLFormClass();
 }
+
+if(window.addEventListener){
+	window.addEventListener('beforeunload',onbeforeunload_unsavedorders,false);
+	console.log("Added onbeforeunload_unsavedorders listener via addEventListener");
+}else{
+	window.attachEvent('onbeforeunload',onbeforeunload_unsavedorders);
+	console.log("Added onbeforeunload_unsavedorders listener via attachEvent");
+}
+
+window.ordersChanged = false;
+
+// When the window is about to change make sure there are no unsubmitted messages around
+function onbeforeunload_unsavedorders(e) {
+
+	// Don't give a warning dialog if no orders were changed
+	if( !window.ordersChanged ) return;
+
+	var str=l_t("You seem to have unsubmitted orders.");
+	var e = e || window.event;
+	
+	// For IE and Firefox
+	if (e) e.returnValue = str;
+	
+	//For Safari
+	return str;
+};

--- a/javascript/utility.js
+++ b/javascript/utility.js
@@ -60,12 +60,22 @@ var inErrorCode=0;
 };
 */
 
+// Attach the method to the unbeforeunload event
+if(window.addEventListener){
+	window.addEventListener('beforeunload',onbeforeunload_unsubmittedtext,false);
+	console.log("Added onbeforeunload_unsubmittedtext listener via addEventListener");
+}else{
+	window.attachEvent('onbeforeunload',onbeforeunload_unsubmittedtext);
+	console.log("Added onbeforeunload_unsubmittedtext listener via attachEvent");
+}
+
 // If false it's okay to leave the page. makeFormsSafe sets this to true, and runs code which makes only
 // certain forms safe.
 window.leavepagedanger=false;
 
 // When the window is about to change make sure there are no unsubmitted messages around
-window.onbeforeunload = function (e) {
+function onbeforeunload_unsubmittedtext(e) {
+	
 	// Don't give a warning dialog if we are submitting the text
 	if( !window.leavepagedanger ) return;
 


### PR DESCRIPTION
Tested under Opera and Firefox

* Opera and Firefox
   * Leaving any page with unsubmitted text will still trigger the warning
   * Leaving the board with unsaved orders will trigger a warning about unsaved orders
   * In case the user selects to leave the page with both unsaved orders and unsubmitted text only one warning (in my case unsaved orders but this does not seem to be guaranteed, according to documentation of addEventListener) will be triggered (even if the user decides to leave the page)

* Special case Firefox
   * No custom text is displayed leaving the user without knowledge why the page requests the navigation

Untested browsers: Internet Explorer (according to specifications of addEventListener some IE versions need to call attachEvent), mobile browsers (according to specifications of unbeforeunload it seems that some mobile browsers seem to (or have been) ignoring the unbeforeunload events.