### PR TITLE
Conversion of (D) into points symbol

### DIFF
--- a/lib/message.php
+++ b/lib/message.php
@@ -52,7 +52,7 @@ class Message
 				'/gameID[:= _]?([0-9]+)/i',
 				'/userID[:= _]?([0-9]+)/i',
 				'/threadID[:= _]?([0-9]+)/i',
-				'/((?:[^a-z0-9])|(?:^))([0-9]+) ?(?:(?:D)|(?:points))((?:[^a-z])|(?:$))/i',
+				'/((?:[^a-z0-9])|(?:^))([0-9]+) ?(?:\(D\))((?:[^a-z])|(?:$))/i',
 			);
 		$replacements = array(
 				'<a href="board.php?gameID=\1" class="light">gameID=\1</a>',


### PR DESCRIPTION
Changed the regex for detection of the points icon to only detect "(d)" [was "d" and "points"].

Attached image shows new outputs. The row with the symbols have been "1(D)", "1(d)", "1 (D)" and "1 (d)"

![points](https://cloud.githubusercontent.com/assets/15995053/14583544/47dcbdee-0425-11e6-9260-54d7a6479928.png)
