### PR TITLE
Update database to version 1.43

### DIFF
--- a/install/1.42-1.43/readme.txt
+++ b/install/1.42-1.43/readme.txt
@@ -1,0 +1,7 @@
+Changelog
+---------
+* Just keeping up with code version
+
+Updating
+--------
+- None

--- a/install/1.42-1.43/update.sql
+++ b/install/1.42-1.43/update.sql
@@ -1,0 +1,1 @@
+UPDATE `wD_Misc` SET `value` = '143' WHERE `name` = 'Version';


### PR DESCRIPTION
The code version had been updated, but the database's had not yet been. This change brings the database up to speed. The only change necessary was the version number itself.