### PR TITLE
Changing Game Passwords to Invite Codes

### DIFF
--- a/css/gamepanel.css
+++ b/css/gamepanel.css
@@ -295,9 +295,10 @@ div.memberBoardHeader {
 	}
 .panelBarGraph {
 	padding:0;
-	margin:0;
 	overflow:hidden;
 	height:6px;
+	margin-left:2%;
+	margin-right:2%;
 }
 .panelBarGraph  {
 }

--- a/gamecreate.php
+++ b/gamecreate.php
@@ -79,7 +79,7 @@ if( isset($_REQUEST['newGame']) and is_array($_REQUEST['newGame']) )
 		// This is hashed, so doesn't need validation
 		if ( $input['password'] != $input['passwordcheck'] )
 		{
-			throw new Exception(l_t("The two passwords entered don't match."));
+			throw new Exception(l_t("The two invite codes entered don't match."));
 		}
 
 		$input['bet'] = (int) $input['bet'];

--- a/gamepanel/game.php
+++ b/gamepanel/game.php
@@ -189,7 +189,7 @@ class panelGame extends Game
 			$buf .= '<img src="'.l_s('images/icons/star.png').'" alt="'.l_t('Featured').'" title="'.l_t('This is a featured game, one of the highest stakes games on the server!').'" /> ';
 
 		if( $this->private )
-			$buf .= '<img src="'.l_s('images/icons/lock.png').'" alt="'.l_t('Private').'" title="'.l_t('This is a private game; password needed!').'" /> ';
+			$buf .= '<img src="'.l_s('images/icons/lock.png').'" alt="'.l_t('Private').'" title="'.l_t('This is a private game; invite code needed!').'" /> ';
 
 		return $buf;
 	}
@@ -395,12 +395,12 @@ class panelGame extends Game
 	}
 
 	/**
-	 * The password box for joining private games
+	 * The invite code box for joining private games
 	 * @return string
 	 */
 	private static function passwordBox()
 	{
-		return ' <span class="gamePasswordBox"><label>'.l_t('Password:').'</label> <input type="password" name="gamepass" size="10" /></span> ';
+		return ' <span class="gamePasswordBox"><label>'.l_t('Invite Code:').'</label> <input type="password" name="gamepass" size="10" /></span> ';
 	}
 
 	/**

--- a/locales/English/gamecreate.php
+++ b/locales/English/gamecreate.php
@@ -88,18 +88,18 @@ Start a new game; you decide the name, how long it runs, and how much it's worth
 	</li>
 
 	<li class="formlisttitle">
-		<img src="images/icons/lock.png" alt="Private" /> Password protect (optional):
+		<img src="images/icons/lock.png" alt="Private" /> Add Invite Code (optional):
 	</li>
 	<li class="formlistfield">
 		<ul>
-			<li>Password: <input type="password" name="newGame[password]" value="" size="30" /></li>
+			<li>Invite Code: <input type="password" name="newGame[password]" value="" size="30" /></li>
 			<li>Confirm: <input type="password" name="newGame[passwordcheck]" value="" size="30" /></li>
 		</ul>
 	</li>
 	<li class="formlistdesc">
-		<strong>This is optional.</strong> If you set this only people who know the password will be able to join.<br /><br />
+		<strong>This is optional.</strong> If you set this only people who know the invite code will be able to join.<br /><br />
 
-		<strong>Default:</strong> No password set
+		<strong>Default:</strong> No invite code set
 	</li>
 </ul>
 


### PR DESCRIPTION
Removing text referring to a game password and replacing it as an invite
code so people no longer think they need to enter their account password
to join a game. Also noticed the country progress color bar was missing
a css 2% margin making it stick out so fixed that too.