### PR TITLE
Adding distinct CSS tags

### DIFF
--- a/css/desktopOnly/gamepanel.css
+++ b/css/desktopOnly/gamepanel.css
@@ -295,9 +295,31 @@ div.memberBoardHeader {
 	}
 .panelBarGraph {
 	padding:0;
-	margin:0;
 	overflow:hidden;
 	height:6px;
+	margin-left:2%;
+	margin-right:2%;
+}
+.panelBarGraphMember {
+	padding:0;
+	overflow:hidden;
+	height:6px;
+	margin-left:0%;
+	margin-right:0%;
+}
+.panelBarGraphCountry {
+	padding:0;
+	overflow:hidden;
+	height:6px;
+	margin-left:0%;
+	margin-right:0%;
+}
+.panelBarGraphTop {
+	padding:0;
+	overflow:hidden;
+	height:6px;
+	margin-left:0%;
+	margin-right:0%;
 }
 .panelBarGraph  {
 }
@@ -325,6 +347,8 @@ div.memberBoardHeader {
 .gamePanelHome .panelBarGraph {
 	margin-top:0;
 	height:4px;
+	margin-left: 0%;
+	margin-right: 0%;
 }
 .memberPointsCount {
 	font-style:italic;

--- a/css/gamepanel.css
+++ b/css/gamepanel.css
@@ -300,6 +300,27 @@ div.memberBoardHeader {
 	margin-left:2%;
 	margin-right:2%;
 }
+.panelBarGraphMember {
+	padding:0;
+	overflow:hidden;
+	height:6px;
+	margin-left:0%;
+	margin-right:0%;
+}
+.panelBarGraphCountry {
+	padding:0;
+	overflow:hidden;
+	height:6px;
+	margin-left:0%;
+	margin-right:0%;
+}
+.panelBarGraphTop {
+	padding:0;
+	overflow:hidden;
+	height:6px;
+	margin-left:0%;
+	margin-right:0%;
+}
 .panelBarGraph  {
 }
 .panelBarGraph td.first {
@@ -326,6 +347,8 @@ div.memberBoardHeader {
 .gamePanelHome .panelBarGraph {
 	margin-top:0;
 	height:4px;
+	margin-left: 0%;
+	margin-right: 0%;
 }
 .memberPointsCount {
 	font-style:italic;

--- a/gamepanel/gameboard.php
+++ b/gamepanel/gameboard.php
@@ -218,7 +218,7 @@ class panelGameBoard extends panelGame
 		$buf = '<a name="gamePanel"></a>';
 		$buf .= $this->header();
 
-		$buf .= '<div class="panelBarGraph occupationBar">'.$this->Members->occupationBar().'</div>';
+		$buf .= '<div class="panelBarGraphTop occupationBar">'.$this->Members->occupationBar().'</div>';
 
 		return '<div class="variant'.$this->Variant->name.'">'.$buf.'</div>';
 	}

--- a/gamepanel/member.php
+++ b/gamepanel/member.php
@@ -48,9 +48,9 @@ class panelMember extends Member
 		$buf = '';
 		libHTML::alternate();
 		if ( $this->Game->phase != 'Pre-game' )
-			$buf .= '<div class="panelBarGraph memberProgressBar barAlt'.libHTML::$alternate.'">'.$this->memberProgressBar().'</div>';
+			$buf .= '<div class="panelBarGraphMember memberProgressBar barAlt'.libHTML::$alternate.'">'.$this->memberProgressBar().'</div>';
 		else
-			$buf .= '<div class="panelBarGraph memberProgressBarBlank"> </div>';
+			$buf .= '<div class="panelBarGraphMember memberProgressBarBlank"> </div>';
 
 		$buf .= '<div class="memberBoardHeader barAlt'.libHTML::$alternate.' barDivBorderTop ">
 			<table><tr class="member">';
@@ -486,7 +486,7 @@ class panelMember extends Member
 				</div>';
 
 		if ( $this->Game->phase != 'Pre-game' )
-			$buf .= '<div class="panelBarGraph memberProgressBar">'.$this->memberProgressBar().'</div>';
+			$buf .= '<div class="panelBarGraphCountry memberProgressBar">'.$this->memberProgressBar().'</div>';
 
 		$buf .= '</td>';
 


### PR DESCRIPTION
The current CSS tags are shared across various different elements making
CSS updates nearly impossible I've split out some of the various
progress bars based on name/location in the game page. Adjusted bar
lengths, and tested on desktop and mobile views, classic, ancient med,
and 1v1 to ensure variant styling wasn't impacted.