### PR TITLE
Fixing anon

### DIFF
--- a/board/chatbox.php
+++ b/board/chatbox.php
@@ -279,8 +279,6 @@ class Chatbox
 			elseif(isset($Game->Members->ByCountryID[$countryID]))
 			{
 				$tabs .= $Game->Members->ByCountryID[$countryID]->memberCountryName();
-				if ( $Game->Members->ByCountryID[$countryID]->online && !$Game->Members->ByCountryID[$countryID]->isNameHidden() )
-					$tabs .= ' '.libHTML::loggedOn($Game->Members->ByCountryID[$countryID]->userID);
 			}
 			else
 			{

--- a/css/desktopOnly/gamepanel.css
+++ b/css/desktopOnly/gamepanel.css
@@ -431,6 +431,10 @@ div.memberBoardHeader {
 	font-size:11px;
 }
 
+.panelAnonOnlyFlag {
+	background-color:#f5f5f5  !important;
+	text-align: center !important;
+	}
 
 .memberVotePanel {
 	border-top: 1px solid #cecece!important;

--- a/css/gamepanel.css
+++ b/css/gamepanel.css
@@ -431,6 +431,10 @@ div.memberBoardHeader {
 	font-size:11px;
 }
 
+.panelAnonOnlyFlag {
+	background-color:#f5f5f5  !important;
+	text-align: center !important;
+	}
 
 .memberVotePanel {
 	border-top: 1px solid #cecece!important;

--- a/forum.php
+++ b/forum.php
@@ -455,7 +455,7 @@ while( $message = $DB->tabl_hash($tabl) )
 	print '<div class="leftRule message-head threadalternate'.$switch.'">
 
 		<a href="profile.php?userID='.$message['fromUserID'].'">'.$message['fromusername'].
-			' '.libHTML::loggedOn($message['fromUserID']).
+			' '.
 				' ('.$message['points'].' '.libHTML::points().User::typeIcon($message['userType']).')</a>'.
 			'<br />
 			<strong><em>'.libTime::text($message['timeSent']).'</em></strong>'.$muteLink.'<br />
@@ -567,7 +567,7 @@ while( $message = $DB->tabl_hash($tabl) )
 			print '<div class="message-head replyalternate'.$replyswitch.' leftRule">';
 
 			print '<strong><a href="profile.php?userID='.$reply['fromUserID'].'">'.$reply['fromusername'].' '.
-			libHTML::loggedOn($reply['fromUserID']).
+			
 					' ('.$reply['points'].' '.libHTML::points().User::typeIcon($reply['userType']).')</a>'.
 				'</strong><br />';
 

--- a/gamepanel/memberhome.php
+++ b/gamepanel/memberhome.php
@@ -60,9 +60,12 @@ class panelMemberHome extends panelMember
 		$buf =array();
 		$buf[] = '<span class="country'.$this->countryID.' '.($User->id==$this->userID?'memberYourCountry':'').
 			' memberStatus'.$this->status.'">'.substr($this->country,0,3).(
-				($this->online &&!$this->isNameHidden()) ? ' '.libHTML::loggedOn($this->userID) : '').'</span>';
+				 '').'</span>';
 
-		$buf[] = $this->memberFinalized();
+		if ($this->Game->anon == 'No')
+		{
+			$buf[] = $this->memberFinalized();
+		}
 		$buf[] = $this->memberSentMessages();
 
 		return $buf;

--- a/index.php
+++ b/index.php
@@ -315,7 +315,7 @@ class libHome
 
 			$buf .= '<div class="hr"></div>';
 			$buf .= $Game->summary();
-		}
+		} 
 
 		if($count==0)
 		{
@@ -341,7 +341,7 @@ class libHome
 		$tabl = $DB->sql_tabl("
 			SELECT m.id as postID, t.id as threadID, m.type, m.timeSent, IF(t.replies IS NULL,m.replies,t.replies) as replies,
 				IF(t.subject IS NULL,m.subject,t.subject) as subject,
-				u.id as userID, u.username, u.points, IF(s.userID IS NULL,0,1) as online, u.type as userType,
+				u.id as userID, u.username, u.points, IF(s.userID IS NULL,0,0) as online, u.type as userType,
 				SUBSTRING(m.message,1,100) as message, m.latestReplySent, t.fromUserID as threadStarterUserID
 			FROM wD_ForumMessages m
 			INNER JOIN wD_Users u ON ( m.fromUserID = u.id )
@@ -417,7 +417,7 @@ class libHome
 
 					<div class="homeForumPostTime">'.libTime::text($post['timeSent']).' '.$post['iconMessage'].'</div>
 					<a href="profile.php?userID='.$post['userID'].'" class="light">'.$post['username'].'</a>
-						'.libHTML::loggedOn($post['userID']) . ' ('.$post['points'].libHTML::points().
+						'.' ('.$post['points'].libHTML::points().
 						User::typeIcon($post['userType']).')
 
 					<div style="clear:both"></div>
@@ -513,7 +513,7 @@ class libHome
 					$buf .= '<div style="clear:both"></div>';
 					$buf .= '<div class="homeForumPostTime" style="float:right"><em>'.libTime::text($t['topic_time']).'</em></div>';
 					$buf .= '<span style=\'font-size:90%\'>';
-					$buf .= 'Thread:</span> <a href="profile.php?userID='.$t['topic_poster_webdip'].'" class="light">'.$t['topic_first_poster_name'].'</a> '.libHTML::loggedOn($t['topic_poster_webdip']);
+					$buf .= 'Thread:</span> <a href="profile.php?userID='.$t['topic_poster_webdip'].'" class="light">'.$t['topic_first_poster_name'].'</a> ';
 					$buf .= '<div style="clear:both"></div></div>';
 					$buf .= '<div class="homeForumPost homeForumPostAlt'.$alt.'">';
 					
@@ -523,7 +523,7 @@ class libHome
 						$buf .= '<div class="" style="margin-bottom:5px;margin-left:3px; margin-right:3px;">';
 						$buf .= '<div class="homeForumPostTime" style="float:right;font-weight:bold"><em>'.libTime::text($t['topic_last_post_time']).'</em></div>';
 						$buf .= '<span style=\'color:#009902;font-size:90%\'>';
-						$buf .= 'Latest:</span> <a href="profile.php?userID='.$t['topic_last_poster_webdip'].'" class="light">'.$t['topic_last_poster_name'].'</a> '.libHTML::loggedOn($t['topic_last_poster_webdip'])
+						$buf .= 'Latest:</span> <a href="profile.php?userID='.$t['topic_last_poster_webdip'].'" class="light">'.$t['topic_last_poster_name'].'</a> '
 						.'</div>';
 					}
 					

--- a/objects/notice.php
+++ b/objects/notice.php
@@ -163,9 +163,6 @@ class notice
 		else
 			$buf = $linkName;
 
-		if( ( $this->type=='PM' || $this->type=='User' ) && isset($this->linkID) && $this->linkID )
-			$buf .= ' '.libHTML::loggedOn($this->linkID);
-
 		return $buf;
 	}
 	public function timeSent()

--- a/objects/user.php
+++ b/objects/user.php
@@ -509,9 +509,6 @@ class User {
 
 			$buffer.='>'.$this->username;
 
-			if ( !$welcome and $this->online )
-				$buffer.= libHTML::loggedOn($this->id);
-
 			$buffer.=' ('.$this->points.libHTML::points().$this->typeIcon($this->type).')</a>';
 		}
 		else

--- a/profile.php
+++ b/profile.php
@@ -405,7 +405,10 @@ if( $total )
 		print '<li>'.l_t($name.': <strong>%s</strong>',$status).'</li>';
 	}
 
-	print '<li>'.l_t('No moves received / received:').' <strong>'.$UserProfile->nmrCount.'/'.$UserProfile->phaseCount.'</strong></li>';
+	if ( $User->type['Moderator'] || $User->id == $UserProfile->id )
+	{
+		print '<li>'.l_t('No moves received / received:').' <strong>'.$UserProfile->nmrCount.'/'.$UserProfile->phaseCount.'</strong></li>';
+	}
 	print '<li>'.l_t('Reliability rating:').' <strong>'.($UserProfile->reliabilityRating).'%</strong>';
 	if( $User->type['Moderator'] || $User->id == $UserProfile->id )
 	{
@@ -466,8 +469,8 @@ if ( $UserProfile->type['Moderator'] ||  $UserProfile->type['ForumModerator'] ||
 	}
 }
 
-if ( $UserProfile->online )
-	print '<li><strong>'.l_t('Currently logged in.').'</strong> ('.libHTML::loggedOn($UserProfile->id).')</li>';
+if ( $UserProfile->online || time() - (24*60*60) < $UserProfile->timeLastSessionEnded)
+	print '<li><strong>'.l_t('Visited in last 24 hours').'</strong></li>';
 else
 	print '<li><strong>'.l_t('Last visited:').'</strong> '.libTime::text($UserProfile->timeLastSessionEnded).'</li>';
 


### PR DESCRIPTION
Does the following:
-Remove online icon from all places except new forum which only shows users who are looking at a forum page
-Change last seen time on profile to show if someone was seen in the last 24 hours, if not, shows the last seen time
-hides NMR count on profiles for non mods and
-hides order icons in anon games for everyone except mods who are not in the game
-adds a message to anon games if someone still needs to enter orders
-100% protects gunboats from broken anon, still 1 vulnerability in press games being explored. 
