### PR TITLE
Allow the TD of a game to see who's who even in anon games

### DIFF
--- a/gamepanel/member.php
+++ b/gamepanel/member.php
@@ -172,11 +172,12 @@ class panelMember extends Member
 	private $isNameHidden;
 	function isNameHidden()
 	{
-		global $User;
+		global $User, $DB;
+		list($directorUserID) = $DB->sql_row("SELECT directorUserID FROM wD_Games WHERE id = ".$this->Game->id);
 
 		if ( !isset($this->isNameHidden) )
 		{
-			if ( $this->Game->isMemberInfoHidden() && $User->id!=$this->userID )
+			if ( ($this->Game->isMemberInfoHidden() && $User->id!=$this->userID) && !(isset($directorUserID) && $directorUserID == $User->id))
 				$this->isNameHidden = true;
 			else
 				$this->isNameHidden = false;


### PR DESCRIPTION
The admins and mods have a long standing rule that you cannot TD a game
you are playing in, so we're allowing TD's to break anon so they can
actually use tools like country swap already available to them.