### PR TITLE
Various Anon Updates

### DIFF
--- a/gamepanel/member.php
+++ b/gamepanel/member.php
@@ -471,6 +471,13 @@ class panelMember extends Member
 
 		return '<span class="member'.$this->id.'StatusIcon">'.$this->orderStatus->icon().'</span>';
 	}
+	
+	function memberFinalizedAnon()
+	{
+		if( $this->status!='Playing' ) return '';
+
+		return '<span class="member'.$this->id.'StatusIcon">'.$this->orderStatus->iconAnon().'</span>';
+	}
 
 	private function muteMember() {
 		global $User;
@@ -509,7 +516,7 @@ class panelMember extends Member
 	function memberBar()
 	{
 		global $User;
-		if ((($User->type['Moderator']) && (! $this->Game->Members->isJoined())) || $this->Game->anon == 'No') 
+		if ($this->Game->anon == 'No' || !$this->isNameHidden) 
 		{
 			$buf = '<td class="memberLeftSide">
 			<span class="memberCountryName">'.$this->memberSentMessages().' '.$this->memberFinalized().$this->memberCountryName().'</span>';
@@ -517,8 +524,7 @@ class panelMember extends Member
 		else
 		{
 			$buf = '<td class="memberLeftSide">
-			<span class="memberCountryName">'.$this->memberSentMessages().$this->memberCountryName().' '.'</span>';
-
+			<span class="memberCountryName">'.$this->memberSentMessages().' '.$this->memberFinalizedAnon().$this->memberCountryName().'</span>';
 		}
 
 		$buf .= $this->muteIcon();

--- a/gamepanel/member.php
+++ b/gamepanel/member.php
@@ -54,12 +54,12 @@ class panelMember extends Member
 		{
 			global $DB;
 			
-			$row = $DB->sql_hash("select count(1) from wD_Members where gameID = ".$this->gameID." and status not like '%Defeated%' and (orderStatus not like '%Saved%' and orderStatus not like '%Completed%' and orderStatus not like '%Ready%')");
+			$row = $DB->sql_hash("select count(1) from wD_Members where gameID = ".$this->gameID." and status not like '%Defeated%' and status not like '%Left%' and (orderStatus not like '%Saved%' and orderStatus not like '%Completed%' and orderStatus not like '%Ready%' and orderStatus not like '%None%')");
 			foreach ( $row as $name=>$value )
 			{
 				$checkMissingOrders = $value;
 			}
-			
+				
 			if ($checkMissingOrders >= 1)
 			{
 				$buf .= '<div class="panelAnonOnlyFlag"><b>At least 1 country still needs to enter orders!</b></div>';

--- a/gamepanel/memberhome.php
+++ b/gamepanel/memberhome.php
@@ -55,16 +55,21 @@ class panelMemberHome extends panelMember
 	 */
 	function memberColumn()
 	{
-		global $User;
+		global $User, $DB;
+		list($directorUserID) = $DB->sql_row("SELECT directorUserID FROM wD_Games WHERE id = ".$this->Game->id);
 
 		$buf =array();
 		$buf[] = '<span class="country'.$this->countryID.' '.($User->id==$this->userID?'memberYourCountry':'').
 			' memberStatus'.$this->status.'">'.substr($this->country,0,3).(
 				 '').'</span>';
 
-		if ($this->Game->anon == 'No')
+		if ($this->Game->anon == 'No' || (isset($directorUserID) && $directorUserID == $User->id))
 		{
 			$buf[] = $this->memberFinalized();
+		}
+		else
+		{
+			$buf[] = $this->memberFinalizedAnon();
 		}
 		$buf[] = $this->memberSentMessages();
 

--- a/objects/basic/set.php
+++ b/objects/basic/set.php
@@ -76,6 +76,21 @@ class setMemberOrderStatus extends set {
 		else
 			return l_t('No orders submitted!');
 	}
+	/*
+		Leaving all possible phases in place for clarity on the possible options to make future changes easier. 
+	*/
+	function iconAnon() {
+		if( $this->None )
+			return '- ';
+		elseif( $this->Ready )
+			return '<img src="'.l_s('images/icons/lock.png').'" alt="'.l_t('Anon').'" title="'.l_t('This country has options this turn').'" /> ';
+		elseif( $this->Completed )
+			return '<img src="'.l_s('images/icons/lock.png').'" alt="'.l_t('Anon').'" title="'.l_t('This country has options this turn').'" /> ';
+		elseif( $this->Saved )
+			return '<img src="'.l_s('images/icons/lock.png').'" alt="'.l_t('Anon').'" title="'.l_t('This country has options this turn').'" /> ';
+		else
+			return '<img src="'.l_s('images/icons/lock.png').'" alt="'.l_t('Anon').'" title="'.l_t('This country has options this turn').'" /> ';
+	}
 }
 class setMemberVotes extends set {
 	protected $allowed=array('Pause','Draw','Cancel');


### PR DESCRIPTION
After the additional anon protection various members complained it was
now difficult to easily see who had retreat or build options on large
maps. This change will replace the !!, !, grey check, and green check
options with the old forum lock icon to indicate who has moves both in
game and on the member home preview. Only game directors will be able to
see through the lock on the home preview (since TD's spectating games is
quite normal) whereas mods spectating games should not need to see
through (I'm planning a future enhancement to hide members in anon games
for mods who are spectating the game).