### PR TITLE
Fixes bugs in the header notification of new forum PMs.

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -566,10 +566,9 @@ class libHTML
 			while($row_hash = $DB->tabl_hash($tabl)) {
 				
 				$profile_link = $row_hash['username'];
-				$profile_link.= libHTML::loggedOn($row_hash['webdip_user_id']);
 				$profile_link.=' ('.$row_hash['points'].libHTML::points().User::typeIcon($row_hash['type']).')';
 				
-				$gameNotifyBlock .= '<span class=""><a href="'.Config::$customForumURL.'/ucp.php?i=pm&mode=view&p='.$row_hash['msg_id'].'">'.
+				$gameNotifyBlock .= '<span class=""><a href="'.Config::$customForumURL.'ucp.php?i=pm&mode=view&p='.$row_hash['msg_id'].'">'.
 						l_t('PM from %s',$profile_link).' <img src="'.l_s('images/icons/mail.png').'" alt="'.l_t('New private message').'" title="'.l_t('New private message!').'" />'.
 						'</a></span> ';
 			}


### PR DESCRIPTION
Specifically:

- Malformed URL sent the user to a page where the PM could be viewed, but all links from that page were broken.
- The notification text included an online indicator, which the site no longer displays anywhere in order to protect anonymity.