### PR TITLE
Add isset to isNameHidden

### DIFF
--- a/gamepanel/member.php
+++ b/gamepanel/member.php
@@ -516,7 +516,7 @@ class panelMember extends Member
 	function memberBar()
 	{
 		global $User;
-		if ($this->Game->anon == 'No' || !$this->isNameHidden) 
+		if ($this->Game->anon == 'No' || (!$this->isNameHidden) && isset($this->isNameHidden))
 		{
 			$buf = '<td class="memberLeftSide">
 			<span class="memberCountryName">'.$this->memberSentMessages().' '.$this->memberFinalized().$this->memberCountryName().'</span>';


### PR DESCRIPTION
The memberBar is called from an external file, which causes various
issues with private variables since they aren't set in that file's
instance. For now, this fix accounts for all cases and renders checks vs
locks for anon for both mods and non mods.