### PR TITLE
Emergency Fix for Issue from PHP Upgrade

### DIFF
--- a/locales/English/user.php
+++ b/locales/English/user.php
@@ -117,14 +117,16 @@ if( $User->type['User'] ) {
 		print '</ul></li>';
 	}
 
+	/*
 	$MutedGames = array();
 	foreach($User->getMuteCountries() as $muteGamePair) {
 		list($gameID, $muteCountryID) = $muteGamePair;
 		if( !isset($MutedGames[$gameID])) $MutedGames[$gameID] = array();
 		$MutedGames[$gameID][] = $muteCountryID;
 	}
+	
 	if( count($MutedGames) > 0 ) {
-		print '<li class="formlisttitle">Muted countries:</li>';
+		print '<li class="formlisttitle">Muted countries:</li>'; 
 		print '<li class="formlistdesc">The countries which you muted, and are unable to send you messages.</li>';
 		print '<li class="formlistfield"><ul>';
 		$LoadedVariants = array();
@@ -134,14 +136,15 @@ if( $User->type['User'] ) {
 				$LoadedVariants[$variantID] = libVariant::loadFromVariantID($variantID);
 			$Game = $LoadedVariants[$variantID]->Game($gameID);
 			print '<li>'.$Game->name.'<ul>';
+			
 			foreach($mutedCountries as $mutedCountryID) {
 				print '<li>'.$Game->Members->ByCountryID[$mutedCountryID]->country.' '.
 				libHTML::muted("board.php?gameID=".$Game->id."&msgCountryID=".$mutedCountryID."&toggleMute=".$mutedCountryID."&rand=".rand(0,99999).'#chatboxanchor').'</li>';
-			}
-			print '</ul></li>';
-		}
+			} 
+			print '</ul></li>'; 
+		} 
 		print '</ul></li>';
-	}
+	} */
 	
 	$tablMutedThreads = $DB->sql_tabl(
 		"SELECT mt.muteThreadID, f.subject, f.replies, fu.username ".


### PR DESCRIPTION
Anyone who went to their settings page if they had active muted countries got this error. 

Catchable fatal error: Object of class __PHP_Incomplete_Class could not be converted to string in /var/www/webdiplomacy.net/public_html/global/error.php on line 107

I was able to narrow the problem down to the specific line:
$LoadedVariants[$variantID] = libVariant::loadFromVariantID($variantID);

The people on google who had the same problem discussed an issue around
serialization after PHP upgrades to version 7 which was just done.
Looking into the failing function libVariant::loadFromVariantID I see it
is also doing serialization, which is far out of my skill set in php. I
did confirm that the other places on the site that use this function are
working as intended. So for the time being I commented out this section
of the settings page and confirmed it no longer crashes for people who
have country mutes.