### PR TITLE
Fix for a rare error in phaseDiplomacy.js

### DIFF
--- a/javascript/orders/phaseDiplomacy.js
+++ b/javascript/orders/phaseDiplomacy.js
@@ -42,7 +42,7 @@ function loadOrdersPhase() {
 									this.FromTerritory, this.ToTerritory, this.Unit.Territory
 								);
 						}
-						else
+						else if( this.ToTerritory.convoyLink )
 						{
 							convoyPath = this.ToTerritory.ConvoyGroup.pathArmyToCoast(this.FromTerritory, this.ToTerritory);
 						}


### PR DESCRIPTION
This is a fix in phaseDiplomacy.js for a rarely occurring error case. The only consequence on webdip despite the error message in the console is a disabled "Ready"-Button even though all entered orders are completed (as the script stopped working before enabling the button). But it is still possible to save and ready after that. Hence this probably was not detected yet. However, on vdip the "Save"-Button is disabled during the entry of an order, as well, causing both buttons to be wrongly disabled. So a fix is a bit more important there.

Cause:
In phaseDiplomacy.js, line 47, it is wrongly assumed that a supported-to-territory has a convoy group (i.e. can be convoyed to). The fix just adds an additional check here. 

Steps to reproduce the error:
Create the situation of to coastal armies with convoy options but also a shared land neighbor (see screenshot: [https://www.dropbox.com/s/42htkss4jz9bd77/supportError.png?dl=0](https://www.dropbox.com/s/42htkss4jz9bd77/supportError.png?dl=0)). Start entering an order on one of the two units that creates "convoyOptions" for that unit. Then support with that unit the other one to the land neighbor. 

Testing:
Directly tested the given test case and some other orders and ran the DATC tests (though I do not checked how many of those test cases actually test the altered code, too, if any at all). Though the fix is rather straightforward (`convoyLink == true` exactly states that there is a ConvoyGroup for the territory / unit so is rather equivalent to `!Object.isUndefined(ConvoyGroup)` which could have been an alternative fix).