### PR TITLE
Update AdminCP

### DIFF
--- a/admin/adminActionsForms.php
+++ b/admin/adminActionsForms.php
@@ -56,6 +56,7 @@ class adminActionsForms
 	 */
 	private static function form($actionName, array $params, $description="")
 	{
+		//print '<div class = "modTools">';
 		print '<form action="'.self::$target.'#'.$actionName.'" method="post">
 			<input type="hidden" name="actionName" value="'.$actionName.'" />';
 
@@ -67,7 +68,7 @@ class adminActionsForms
 			print '<input type="hidden" name="globalPostID" value="'.intval($_REQUEST['globalPostID']).'" />';
 		
 		if ($description)
-			print '<li class="formlistdesc" style="margin-bottom:10px">'.l_t($description).'</li>';
+			print '<li class="modToolsformlistdesc" style="margin-bottom:10px">'.l_t($description).'</li>';
 
 		foreach( $params as $paramCode=>$paramName )
 		{
@@ -83,18 +84,19 @@ class adminActionsForms
 			else
 				$defaultValue = '';
 
-			print '<li class="formlistfield">
+			print '<li class="modToolsformlistfield">
 					<label for="'.$paramCode.'">'.l_t($paramName).'</label>:
-					<input type="text" name="'.$paramCode.'" value="'.$defaultValue.'" length="50" />
+					<input class = "modTools" type="text" name="'.$paramCode.'" value="'.$defaultValue.'" length="50" />
 					</li>';
 		}
 
-		print '<li class="formlistfield" style="margin-bottom:20px">
-			<input class="form-submit" type="submit" name="Submit" value="'.l_t('Submit').'" /> '.
+		print '<li class="modToolsformlistfield" style="margin-bottom:20px">
+			<input class="modToolsform-submit" type="submit" name="Submit" value="'.l_t('Submit').'" /> '.
 			( self::isActionDangerous($actionName) ? '<em>('.l_t('Careful; not confirmed!').')</em>' : '').'
 			</li>';
 
 		print '</form>';
+		print '</div></br>';
 	}
 
 	private static function isActionDangerous($actionCode)
@@ -150,14 +152,15 @@ class adminActionsForms
 		// TODO: Use late static binding for this instead of INBOARD detection
 		extract($this->actionsList[$actionName]);
 
-		print '<li class="formlisttitle">
+		print '<div class = "modToolsCP">';
+		print '<li class="modToolsformlisttitle">
 			<a name="'.$actionName.'"></a>'.l_t($name).'</li>';
 
 		try
 		{
 			if ( isset($_REQUEST['actionName']) and $_REQUEST['actionName'] == $actionName )
 			{
-				print '<li class="formlistfield">';
+				print '<li class="modToolsformlistfield">';
 
 				$paramValues = array();
 				foreach($params as $paramName=>$paramFullName)
@@ -199,7 +202,7 @@ class adminActionsForms
 						print '<input type="hidden" name="'.$name.'" value="'.$value.'" />';
 
 					print '</li><li class="formlistfield" style="margin-bottom:20px">
-						<input type="submit" class="form-submit" value="Confirm" />
+						<input type="submit" class="modToolsform-submit" value="Confirm" />
 
 						</form>';
 				}
@@ -301,23 +304,22 @@ class adminActionsLayout
 		$actionCount = count($actionCodes);
 		$actionMidPoint = ceil($actionCount/2);
 
-		print '<div style="width:90%; margin-left:auto; margin-right:auto">';
+		print '<div class="modTools" style="width:90%; margin-left:auto; margin-right:auto">';
 
-		print '<div style="float:right; width:50%; text-align:left">';
+		print '<div class="modTools" style="float:right; width:50%; text-align:left">';
 		for($i=$actionMidPoint; $i<$actionCount; $i++)
 		{
-			print '<a href="#'.$actionCodes[$i].'">'.l_t(adminActions::$actions[$actionCodes[$i]]['name']).'</a><br />';
+			print '<a class="modTools" href="#'.$actionCodes[$i].'">'.l_t(adminActions::$actions[$actionCodes[$i]]['name']).'</a><br />';
 		}
 		print '</div>';
 
 		print '<div style="width:45%">';
 		for($i=0; $i<$actionMidPoint; $i++)
 		{
-			print '<a href="#'.$actionCodes[$i].'">'.l_t(adminActions::$actions[$actionCodes[$i]]['name']).'</a><br />';
+			print '<a class="modTools" href="#'.$actionCodes[$i].'">'.l_t(adminActions::$actions[$actionCodes[$i]]['name']).'</a><br />';
 		}
 		print '</div>';
-		print '<div style="clear:both"></div>';
-
+		print '<div class="modTools" style="clear:both"></div>';
 		print '</div>';
 	}
 }
@@ -328,7 +330,6 @@ if ( isset($_REQUEST['globalUserID']) )
 	adminActionsForms::$globalUserID = (int)$_REQUEST['globalUserID'];
 if ( isset($_REQUEST['globalPostID']) )
 	adminActionsForms::$globalPostID = (int)$_REQUEST['globalPostID'];
-
 
 // A shortcut command area
 require_once(l_r('lib/gamemessage.php'));
@@ -370,21 +371,21 @@ else
 	
 	$actionCodesByType = adminActionsLayout::actionCodesByType();
 	
-	print '<h3>'.l_t('Admin actions').'</h3>';
+	print '<h2 class="modToolsHeadings">'.l_t('Menu').'</h2>';
 	foreach($actionCodesByType as $type=>$actionCodes)
 	{
-		print '<a name="'.strtolower($type).'Actions"></a><h4>'.l_t($type.' actions').'</h4>';
+		print '<a name="'.strtolower($type).'Actions"></a><h3 class = "modToolsHeadings">'.l_t($type.' actions').'</h3>';
 		adminActionsLayout::printActionLinks($actionCodes);
 	}
 	
 	print '<div class="hr"></div>';
 	
-	print '<h3>'.l_t('Forms').'</h3>';
+	print '<h2 class="modToolsHeadings">'.l_t('All Actions').'</h2>';
 	// For each task display the form, and run the task if data entered from the corresponding form
 	print '<ul class="formlist">';
 	foreach($actionCodesByType as $type=>$actionCodes)
 	{
-		print '<h4>'.l_t($type.' actions').'</h4>';
+		print '<h3 class="modToolsHeadings">'.l_t($type.' actions').'</h3>';
 	
 		foreach($actionCodes as $actionCode)
 			$adminActions->process($actionCode);

--- a/admin/adminChatAnalyser.php
+++ b/admin/adminChatAnalyser.php
@@ -111,8 +111,9 @@ if ($gameID != 0)
 	libVariant::setGlobals($Variant);
 	$Game = $Variant->panelGameBoard($gameID);
     
-    // Because moderators cannot break anon for their own games do not load the page at all if they are in the game. Die and log attempted access.
-    list($modInGame) = $DB->sql_row("SELECT count(1) FROM wD_Members WHERE userID = ".$User->id." and gameID =".$gameID);
+    // Because moderators cannot break anon for their own games do not load the page at all if the mod is in the game which is unfinished. Die and log attempted access.
+	list($modInGame) = $DB->sql_row("SELECT count(1) FROM wD_Members m INNER JOIN wD_Games g ON ( g.id = m.gameID ) WHERE m.userID = ".$User->id." and m.gameID =".$gameID." AND NOT g.phase = 'Finished'");
+	
     if ($modInGame == 1)
     {
         $reason = "Press was not checked on gameID:". $gameID. " because the moderator was in the game.";

--- a/admin/adminMultiFinder.php
+++ b/admin/adminMultiFinder.php
@@ -120,11 +120,10 @@ class adminMultiCheck
 				'and gives a more detailed picture of what is happening.').'
 				</p>';
 
-		print '<p><strong>'.l_t('Links between users share active public games:').'</strong>
+		print '<p><strong>'.l_t('Links between users share public games:').'</strong>
 				<input type="checkbox" name="activeLinks" /><br />
-				'.l_t('With this checked links between users will be ignored if they aren\'t currently playing in '.
-				'the same public games. This helps ensure that the data being checked is relevant and cuts out the '.
-				'clutter.').'
+				'.l_t('Ignores links if the users have not played in '.
+				'the same public games. If there are no shared public game connections the normal multi finder results will be displayed instead.').'
 				</p>';
 
 		print '<input type="submit" name="Submit" class="form-submit" value="'.l_t('Check').'" />
@@ -480,7 +479,7 @@ class adminMultiCheck
 		$this->aLogsData['activeGameIDs'] = self::sql_list(
 			"SELECT DISTINCT m.gameID
 			FROM wD_Members m INNER JOIN wD_Games g ON ( g.id = m.gameID )
-			WHERE m.userID = ".$this->aUserID." AND NOT g.phase = 'Finished' and g.password is null"
+			WHERE m.userID = ".$this->aUserID." and g.password is null"
 		);
 	}
 

--- a/css/global.css
+++ b/css/global.css
@@ -708,7 +708,15 @@ TD.army, div.army {
 .modTools {
 	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
 	border-collapse: collapse;
-  }
+}
+
+input[type="text"].modTools, input[type="password"].modTools, textarea.modTools, select.modTools {
+	font-size: 14px;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	background-color: #ffffff !important;
+	border: 1px solid #c1c1c1;
+	color:#000000;
+}
   
 .modTools td, .modTools th {
 	border: 1px solid #ddd;
@@ -724,6 +732,60 @@ TD.army, div.army {
 	text-align: left;
 	background-color: #009902;
 	color: white;
+}
+
+.modToolsCP {
+	border-radius: 25px;
+	background: rgb(222, 224, 222);
+	padding: 8px; 
+}
+
+.modToolsHeadings {
+    color: #000000 !important;
+	margin-bottom: 5px;
+	font-weight: bold;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	text-decoration: underline;
+}
+
+li.modToolsformlistfield {
+	list-style: none;
+	margin-bottom:10px;
+	margin-left:20px;
+	margin-right:20px;
+	margin-top:5px;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+}
+li.modToolsformlistdesc {
+	font-weight: normal;
+	color: #000000b2 !important;
+	list-style: none;
+	margin-left:20px;
+	margin-right:20px;
+	border-left: 1px solid #aaa;
+	padding-left: 10px;
+	margin-bottom: 30px;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+}
+li.modToolsformlisttitle {
+	font-weight: bold;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	text-decoration: underline;
+}
+.modToolsform-submit {
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	color: #fff !important;
+	text-transform: uppercase;
+	background: #60a3bc !important;
+	padding: 5px;
+	border-radius: 50px;
+	display: inline-block;
+	border: none;
+}
+.modToolsform-submit:hover {
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	text-shadow: 0px 0px 6px rgba(255, 255, 255, 1);
+	transition: all 0.4s ease 0s;
 }
 
 .topnav {


### PR DESCRIPTION
1. update control panel styling.
2. update control panel descriptions
3. changed cancel game to no longer try and refund points on finished games which will remove the issue of cancelled finished games throwing an error.
4. changed force user into CD to allow it to work on a pre-start game by just kicking that person from the game, and if they were the only person in it, deleting the game and resetting the min bet on the game if the weren't. Preventing the issue of mods being helpless on crashed pre-start games.
5. updated the multi finder "active  games" checkbox to say "public games" so it's no longer only looking for active it'll look for people with any public game connections
6. Fix issue in press checker that prevented mods from pulling press in their own finished games.