### PR TITLE
Additional Cleanup of AdminCP

### DIFF
--- a/admin/adminActions.php
+++ b/admin/adminActions.php
@@ -100,36 +100,6 @@ class adminActions extends adminActionsForms
 				'description' => 'Resets a users password',
 				'params' => array('userID'=>'User ID'),
 			),
-			'makeDonator' => array(
-				'name' => 'Give donator benefits',
-				'description' => 'Give donator benefits (in practical terms this just means opt-out of the distributed processing).<br />
-					<em>Only for owner use.</em>',
-				'params' => array('userID'=>'User ID'),
-			),
-			'makeDonatorPlatinum' => array(
-				'name' => 'Donator: platinum',
-				'description' => 'Give platinum donator marker<br />
-					<em>Only for owner use.</em>',
-				'params' => array('userID'=>'User ID'),
-			),
-			'makeDonatorGold' => array(
-				'name' => 'Donator: gold',
-				'description' => 'Give gold donator marker<br />
-					<em>Only for owner use.</em>',
-				'params' => array('userID'=>'User ID'),
-			),
-			'makeDonatorSilver' => array(
-				'name' => 'Donator: silver',
-				'description' => 'Give silver donator marker<br />
-					<em>Only for owner use.</em>',
-				'params' => array('userID'=>'User ID'),
-			),
-			'makeDonatorBronze' => array(
-				'name' => 'Donator: bronze',
-				'description' => 'Give bronze donator marker<br />
-					<em>Only for owner use.</em>',
-				'params' => array('userID'=>'User ID'),
-			),
 			'setProcessTimeToPhase' => array(
 				'name' => 'Reset process time',
 				'description' => 'Set a game process time to now + the phase length, resetting the turn length',
@@ -218,11 +188,6 @@ class adminActions extends adminActionsForms
 					Note: Doesn\'t work.',
 				'params' => array('userID'=>'User ID'),
 			),
-			'syncForumLikes' => array(
-				'name' => 'Sync forum likes',
-				'description' => 'Synchronizes the cached forum post like counts with the user-tracked like records, in case they somehow get out of sync.',
-				'params' => array(),
-			),
 			'setDirector' => array(
 				'name' => 'Set a user as a game director',
 				'description' => 'Sets the given user ID to be the director of the given game ID (set to 0 to remove someone as game director). 
@@ -242,22 +207,6 @@ class adminActions extends adminActionsForms
 		$Game = $Variant->processGame($params['gameID']);
 		$Game->resetMinimumBet();
 		return l_t("The minimum bet has been reset.");
-		
-	}
-	public function syncForumLikes(array $params)
-	{
-		global $DB;
-		
-		$DB->sql_put("UPDATE wD_ForumMessages fm
-			INNER JOIN (
-			SELECT f.id, COUNT(*) as likeCount
-			FROM wD_ForumMessages f
-			INNER JOIN wD_LikePost lp ON f.id = lp.likeMessageID
-			GROUP BY f.id
-			) l ON l.id = fm.id
-			SET fm.likeCount = l.likeCount");
-		
-		return l_t("All forum like counts have been synced, %s posts affected.", $DB->last_affected());
 	}
 	
 	public function unCrashGames(array $params)
@@ -664,36 +613,7 @@ class adminActions extends adminActionsForms
 		return l_t('Panic button '.($Misc->Panic?'turned on':'turned off'));
 	}
 
-	private function makeDonatorType(array $params, $type='') {
-		global $DB;
-
-		$userID = (int)$params['userID'];
-
-		$DB->sql_put("UPDATE wD_Users SET type = CONCAT_WS(',',type,'Donator".$type."') WHERE id = ".$userID);
-
-		return l_t('User ID %s given donator status.',$userID);
-	}
-
-	public function makeDonator(array $params)
-	{
-		return $this->makeDonatorType($params);
-	}
-	public function makeDonatorPlatinum(array $params)
-	{
-		return $this->makeDonatorType($params,'Platinum');
-	}
-	public function makeDonatorGold(array $params)
-	{
-		return $this->makeDonatorType($params,'Gold');
-	}
-	public function makeDonatorSilver(array $params)
-	{
-		return $this->makeDonatorType($params,'Silver');
-	}
-	public function makeDonatorBronze(array $params)
-	{
-		return $this->makeDonatorType($params,'Bronze');
-	}
+	
 
 	public function resetPassConfirm(array $params)
 	{

--- a/admin/adminActionsForms.php
+++ b/admin/adminActionsForms.php
@@ -237,28 +237,19 @@ class adminActionsLayout
 	{
 		global $User;
 
-		$modActions=array();
-		$modActions[] = '<a href="gamemaster.php" class="light">'.l_t('Run gamemaster').'</a><br />';
-		$modActions[] = libHTML::admincp('panic', null, l_t('Toggle panic-mode'));
+		print '<div class = "modTools">';
+		print '<ul class = "modTools">';
+		print '<li><a href="gamemaster.php" class="modTools">'.l_t('Run gamemaster').'</a></li>';
+		print '<li><a href="admincp.php?tab=Control%20Panel&actionName=panic#panic" class="modTools">'.l_t('Toggle Panic Mode').'</a></li>';
 
 		if($User->type['Admin'])
 		{
-			$modActions[] = libHTML::admincp('notice', null, l_t('Toggle the site-wide notice'));
-			$modActions[] = libHTML::admincp('maintenance', null, l_t('Toggle maintenance-mode')).'<br />';
-			$modActions[] = libHTML::admincp('clearErrorLogs', null, l_t('Clear error-logs'));
-			$modActions[] = libHTML::admincp('clearOrderLogs', null, l_t('Clear order-logs'));
-			$modActions[] = libHTML::admincp('clearAccessLogs', null, l_t('Clear access-logs'));
-			$modActions[] = libHTML::admincp('clearAdminLogs', null, l_t('Clear admin-logs')).'<br />';
-			$modActions[] = libHTML::admincp('unCrashGames', array('excludeGameIDs'=>''), l_t('Un-crash any crashed games'));
+			print '<li><a href="admincp.php?tab=Control%20Panel&actionName=notice#notice" class="modTools">'.l_t('Toggle Site Notice').'</a></li>';
+			print '<li><a href="admincp.php?tab=Control%20Panel&actionName=maintenance#maintenance" class="modTools">'.l_t('Toggle Maintenance Mode').'</a></li>';
 		}
 
-		if($modActions)
-		{
-			print '<p class="notice">';
-			print implode(' - ', $modActions);
-			print '</p>';
-			print '<div class="hr"></div>';
-		}
+		print '<li><a href="admincp.php?tab=Control%20Panel&actionName=unCrashGames&excludeGameIDs=#unCrashGames" class="modTools">'.l_t('Un-Crash Games').'</a></li>';
+		print '</div>';
 	}
 
 	private static function sortedActionCodes()
@@ -354,7 +345,7 @@ if( defined("INBOARD") )
 }
 else
 {
-	print '<div class="hr"></div>';
+	print '<h2 class="modToolsHeadings">'.l_t('Emergency Actions').'</h2>';
 	adminActionsLayout::printActionShortcuts();
 	
 	if ( $User->type['Admin'] )

--- a/admin/adminActionsRestricted.php
+++ b/admin/adminActionsRestricted.php
@@ -89,6 +89,36 @@ class adminActionsRestricted extends adminActionsForum
 				'description' => 'Takes forum moderator status from the specified user ID.',
 				'params' => array('userID'=>'Mod User ID'),
 			),
+			'makeDonator' => array(
+				'name' => 'Give donator benefits',
+				'description' => 'Give donator benefits (in practical terms this just means opt-out of the distributed processing).<br />
+					<em>Only for owner use.</em>',
+				'params' => array('userID'=>'User ID'),
+			),
+			'makeDonatorPlatinum' => array(
+				'name' => 'Donator: platinum',
+				'description' => 'Give platinum donator marker<br />
+					<em>Only for owner use.</em>',
+				'params' => array('userID'=>'User ID'),
+			),
+			'makeDonatorGold' => array(
+				'name' => 'Donator: gold',
+				'description' => 'Give gold donator marker<br />
+					<em>Only for owner use.</em>',
+				'params' => array('userID'=>'User ID'),
+			),
+			'makeDonatorSilver' => array(
+				'name' => 'Donator: silver',
+				'description' => 'Give silver donator marker<br />
+					<em>Only for owner use.</em>',
+				'params' => array('userID'=>'User ID'),
+			),
+			'makeDonatorBronze' => array(
+				'name' => 'Donator: bronze',
+				'description' => 'Give bronze donator marker<br />
+					<em>Only for owner use.</em>',
+				'params' => array('userID'=>'User ID'),
+			),
 			'reprocessGame' => array(
 				'name' => 'Reprocess game',
 				'description' => 'Returns an active game to the last Diplomacy phase,
@@ -614,6 +644,36 @@ class adminActionsRestricted extends adminActionsForum
 		require_once(l_r('gamemaster/gamemaster.php'));
 		libGameMaster::updateReliabilityRating(true);
 		return l_t("Reliability Ratings have been recalculated");
+	}
+	private function makeDonatorType(array $params, $type='') {
+		global $DB;
+
+		$userID = (int)$params['userID'];
+
+		$DB->sql_put("UPDATE wD_Users SET type = CONCAT_WS(',',type,'Donator".$type."') WHERE id = ".$userID);
+
+		return l_t('User ID %s given donator status.',$userID);
+	}
+
+	public function makeDonator(array $params)
+	{
+		return $this->makeDonatorType($params);
+	}
+	public function makeDonatorPlatinum(array $params)
+	{
+		return $this->makeDonatorType($params,'Platinum');
+	}
+	public function makeDonatorGold(array $params)
+	{
+		return $this->makeDonatorType($params,'Gold');
+	}
+	public function makeDonatorSilver(array $params)
+	{
+		return $this->makeDonatorType($params,'Silver');
+	}
+	public function makeDonatorBronze(array $params)
+	{
+		return $this->makeDonatorType($params,'Bronze');
 	}
 }
 

--- a/admin/adminLog.php
+++ b/admin/adminLog.php
@@ -26,7 +26,7 @@ defined('IN_CODE') or die('This script can not be run by itself.');
  * @package Admin
  */
 
-
+print '<br />';
 if( !isset($_REQUEST['full']) )
 	print '<a class="modTools" href="admincp.php?tab=Logs&full=on">'.l_t('View all logs').'</a>';
 

--- a/admin/adminStatusLists.php
+++ b/admin/adminStatusLists.php
@@ -139,9 +139,9 @@ if( $User->type['Admin'] ) {
 	}
 
 	print '<p class="modTools"><strong>'.l_t('Order logs:').'</strong><form class="modTools" action="admincp.php" method="get">
-		'.l_t('Game ID').': <input type="text" name="viewOrderLogGameID" value="'.$viewOrderLogGameID.'" />
-		'.l_t('CountryID').': <input type="text" name="viewOrderLogCountryID" value="'.$viewOrderLogCountryID.'" />
-		<input class="modTools" type="submit" name="'.l_t('Submit').'" /></form></p>';
+		'.l_t('Game ID').': <input class="modTools" type="text" name="viewOrderLogGameID" value="'.$viewOrderLogGameID.'" />
+		'.l_t('CountryID').': <input class="modTools" type="text" name="viewOrderLogCountryID" value="'.$viewOrderLogCountryID.'" />
+		<input class="modToolsform-submit" type="submit" name="'.l_t('Submit').'" /></form></p>';
 }
 
 /*

--- a/css/global.css
+++ b/css/global.css
@@ -723,8 +723,8 @@ input[type="text"].modTools, input[type="password"].modTools, textarea.modTools,
 	padding: 6px;
 }
 
-.modTools tr:nth-child(even){background-color: #f2f2f2;}
-.modTools tr:nth-child(odd){background-color: #ffffff;}
+.modTools tr:nth-child(even){background-color: #f2f2f2; word-break: break-word;}
+.modTools tr:nth-child(odd){background-color: #ffffff; word-break: break-word;}
 
 .modTools th {
 	padding-top: 12px;
@@ -732,6 +732,7 @@ input[type="text"].modTools, input[type="password"].modTools, textarea.modTools,
 	text-align: left;
 	background-color: #009902;
 	color: white;
+	min-width:70px
 }
 
 .modToolsCP {


### PR DESCRIPTION
Fixing cluttered emergency actions that previously was too easy to hit a non confirmed action on a phone. Since these included wiping admin logs it presented a serious data loss risk. Clearing log actions were removed from this section.

Moving sync forum likes to forum mod status

Moving donator perks to admin only

Fixing control panel logs to break words and to resize to phones.