### PR TITLE
Fix Vanishing Join Button

### DIFF
--- a/admin/adminActions.php
+++ b/admin/adminActions.php
@@ -861,13 +861,13 @@ class adminActions extends adminActionsForms
 			// If the game hasn't started check if there's just 1 person in it. If there is then delete the game, otherwise remove that 1 user.  
 			else if( $Game->phase == 'Pre-game' )
 			{
-				if(count($Game->Members->ByID)==1)
-				{
+				if(count($Game->Members->ByID)==1) {
 					processGame::eraseGame($Game->id);
 				}
-				else
-				{
+				else{
 					$DB->sql_put("DELETE FROM wD_Members WHERE gameID = ".$Game->id." AND userID = ".$params['userID']);
+					
+					// If there are still people in the game reset the min bet in case the game was full to readd the join button.
 					$Game->resetMinimumBet();
 				}
 			}
@@ -1065,6 +1065,11 @@ class adminActions extends adminActionsForms
 			if( $Game->phase != 'Finished' && $Game->phase != 'Pre-game')
 			{
 				$Game->Members->ByUserID[$userID]->setLeft(1);
+				$Game->resetMinimumBet();
+			}
+			else if($Game->phase == 'Pre-game')
+			{
+				// If there are still people in the game reset the min bet in case the game was full to readd the join button.
 				$Game->resetMinimumBet();
 			}
 

--- a/gamemaster/member.php
+++ b/gamemaster/member.php
@@ -62,6 +62,9 @@ class processMember extends Member
 		{
 			// Notify the remaining players
 			$Game->Members->sendExcept($this,'No',l_t("<strong>%s</strong> left the game.",$this->username));
+
+			// If there are still people in the game reset the min bet in case the game was full to readd the join button.
+			$Game->resetMinimumBet();
 		}
 
 		header('refresh: 4; url=index.php');


### PR DESCRIPTION
There were several scenarios where a live game could have a player leave or be removed without the min bet on the game being reset, which would cause the game to not have a join button even if it wasn't full.

1. a Mod bans a user in a full pre-start live game.
2. a player in a full pre-start live game leaves.

This has been causing multiple live games to be non-startable despite enough interest.

Adjusted by adding a call to the resetMinimumBet function. This isn't an ideal fix cause it won't be apparent for people working on game code but should work for now.