### PR TITLE
Fix 10 year Issue

### DIFF
--- a/gamemaster/game.php
+++ b/gamemaster/game.php
@@ -392,7 +392,13 @@ class processGame extends Game
 		if ( $this->phase == 'Pre-game' )
 		{
 			if ( count($this->Members->ByID)<count($this->Variant->countries) )
-				$minimumBet = ceil($this->pot / count($this->Members->ByID));
+				{
+				// The old logic here did not work in many cases, pre game everyone should be entering the game with the same bet,
+				// there is no need to do anything fancy to figure it out. 
+				// $minimumBet = ceil($this->pot / count($this->Members->ByID));
+				list($getMinBet) = $DB->sql_row("select min(bet) from wD_Members where gameID = ".$this->id);
+				$minimumBet = $getMinBet;
+			}
 		}
 		elseif ( $this->phase != 'Finished' )
 		{

--- a/gamemaster/member.php
+++ b/gamemaster/member.php
@@ -51,6 +51,9 @@ class processMember extends Member
 
 		$this->cancelBet();
 
+		// This logic is deleting the record from the database, and intentionally not reloading the this object to have a new count of
+		// number of records in the database so that the count in the if statement will equal 1. This is amazingly deceptive code and 
+		// needs to be fixed at some point.
 		$DB->sql_put("DELETE FROM wD_Members WHERE id=".$this->id);
 
 		if(count($Game->Members->ByUserID)==1)


### PR DESCRIPTION
The reset min bet function was never right for being called as a user was being removed from a pre-start game. The way the logic worked meant the user count wouldn't refect the real user count in the members table. Only discovered when the resetminbet function began getting called when it was initially supposed to. Count is now being pulled direct from the db to avoid state issues.