### PR TITLE
Fix game search issues

### DIFF
--- a/gamelistings.php
+++ b/gamelistings.php
@@ -81,7 +81,7 @@ function printAndFindTab()
 		$tabs['My games']=l_t("Active games which you have joined");
 
 	$tabs['New']=l_t("Games which haven't yet started");
-	$tabs['Joinable']=l_t("Public Games which have open spaces");
+	$tabs['Joinable']=l_t("Public games which have open spaces");
 	$tabs['Active']=l_t("Games which are going on now");
 	$tabs['Finished']=l_t("Games which have ended");
 	$tabs['Search']=l_t("The full game listing search panel");

--- a/gamelistings.php
+++ b/gamelistings.php
@@ -81,7 +81,7 @@ function printAndFindTab()
 		$tabs['My games']=l_t("Active games which you have joined");
 
 	$tabs['New']=l_t("Games which haven't yet started");
-	$tabs['Joinable']=l_t("Games which have open spaces");
+	$tabs['Joinable']=l_t("Public Games which have open spaces");
 	$tabs['Active']=l_t("Games which are going on now");
 	$tabs['Finished']=l_t("Games which have ended");
 	$tabs['Search']=l_t("The full game listing search panel");

--- a/gamemaster/misc.php
+++ b/gamemaster/misc.php
@@ -82,7 +82,7 @@ class miscUpdate
 		list($Misc->GamesFinished) = $DB->sql_row("SELECT COUNT(phase) FROM wD_Games WHERE phase = 'Finished'");
 		list($Misc->GamesCrashed) = $DB->sql_row("SELECT COUNT(processStatus) FROM wD_Games WHERE processStatus = 'Crashed'");
 		list($Misc->GamesPaused) = $DB->sql_row("SELECT COUNT(processStatus) FROM wD_Games WHERE processStatus = 'Paused'");
-		list($Misc->GamesOpen) = $DB->sql_row("SELECT COUNT(DISTINCT gameID) FROM wD_Members WHERE status='Left'");
+		list($Misc->GamesOpen) = $DB->sql_row("SELECT COUNT(1) FROM wD_Games g WHERE g.minimumBet is not null and g.password is null and g.gameOver = 'No' and g.phase <> 'Pre-game'");
 
 		if( $Misc->GamesActive >= 16 )
 		{

--- a/gamesearch/searchItemSettings.php
+++ b/gamesearch/searchItemSettings.php
@@ -499,8 +499,8 @@ class searchOrderBy extends searchItemSelect
 	protected $options=array(
 			'-'=>'None',
 			'processTime-ASC'=>'Time until next process (Closest-&gt;furthest)',
-			'phaseMinutes-DESC'=>'Hours per phase (Longest-&gt;shortest)',
-			'phaseMinutes-ASC'=>'Hours per phase (Shortest-&gt;longest)',
+			'phaseMinutes-DESC'=>'Time per phase (Longest-&gt;shortest)',
+			'phaseMinutes-ASC'=>'Time per phase (Shortest-&gt;longest)',
 			'pot-DESC'=>'Pot size (Largest-&gt;smallest)',
 			'pot-ASC'=>'Pot size (Smallest-&gt;largest)',
 			'minimumBet-DESC'=>'Bet size (Largest-&gt;smallest)',


### PR DESCRIPTION
Rename hover over text on "Joinable" to inform that it's public games only.

Redo wD_Misc GamesOpen query to correctly pull the number of joinable games. Old query was incorrect.

Rename "Hours per phase" in search criteria to "Time per phase" since all phases aren't hours like live games and 10 day games.