### PR TITLE
Revamping Help Section Pages

### DIFF
--- a/contactUs.php
+++ b/contactUs.php
@@ -1,0 +1,35 @@
+<?php
+/*
+    Copyright (C) 2004-2010 Kestas J. Kuliukas
+
+	This file is part of webDiplomacy.
+
+    webDiplomacy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    webDiplomacy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with webDiplomacy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @package Base
+ * @subpackage Static
+ */
+
+require_once('header.php');
+
+libHTML::starthtml();
+
+print libHTML::pageTitle(l_t('Contact the Moderators'),l_t('Learn how to contact the moderators and what information to include.'));
+
+require_once(l_r('locales/English/contactUs.php'));
+
+print '</div>';
+libHTML::footer();

--- a/css/global.css
+++ b/css/global.css
@@ -740,6 +740,8 @@ TD.army, div.army {
 		background-color: #f1f1f1;
 		margin-top: 0px !important;
 		font-size: 14px;
+		border-radius: 7px;
+		padding: 0 0 0 10px;
   } 
 /* End of section for FAQ styling */
 
@@ -769,34 +771,103 @@ TD.army, div.army {
 /* End of section for Hall of Fame styling */
 
 /* Section for credits page styling */
-
 .credits {
 	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
 }
 
 .credits-title {
-	background-color: #555;
-	border-radius: 7px;
+	background-color: #777;
 	color: white;
+	cursor: pointer;
+	padding: 10px;
+	border: none;
+	text-align: left;
+	outline: none;
+	border-radius: 7px;
+	margin-top: 3px;
+	font-size: 14px;
 }
 
 .credits-info {
-	background-color: #f1f1f1;
-	overflow: hidden;
 	border-radius: 7px;
+	padding: 10px;
+	overflow: hidden;
+	background-color: #f1f1f1;
+	font-size: 14px;
 	margin: 0 0 15px 0 !important;
 }
 
-.credits-title, .credits-info {
-	padding: 10px;
-}
-
 #credits-player-map-a, #credits-player-map-a:active {
-	color: white;
+	color: rgb(84, 228, 238);
 	cursor: pointer;
 }
-
 /* end of credits page styling */
+
+/* Section for Rules styling */
+.helpPage em {
+	text-decoration:underline;
+	font-style:normal;
+}
+.helpPage h3 {
+	margin-left: 0px !important;
+}
+.helpPage ul {
+	color:#666;
+}
+.helpPage ol {
+	color:#666;
+}
+
+.rules {
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	border-collapse: collapse;
+	/* font-size: 14px; */
+}
+.rules h3{
+	margin-left: 0px !important;
+}
+
+ .rules_title {
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	background-color: #777;
+	color: white;
+	cursor: pointer;
+	padding: 10px;
+	border: none;
+	text-align: left;
+	outline: none;
+	border-radius: 7px;
+	margin-top: 3px;
+	font-size: 14px;
+}
+
+  .rules_title:hover {
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	background-color: #555;
+  }
+
+  .rules_content {
+		padding: 0;
+		font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+		display: none;
+		overflow: hidden;
+		padding: 0 0 0 10px;
+		background-color: #f1f1f1;
+		font-size: 14px;
+		margin-top:0px !important; 
+		border-radius: 7px;
+	} 
+	
+	.rules_content_show {
+		border-radius: 7px;
+		font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+		overflow: hidden;
+		background-color: #f1f1f1;
+		font-size: 14px;
+		padding: 0 0 0 10px;
+		margin-top:0px !important; 
+  } 
+/* End of section for Rules styling */
 
 /* This section is for the new AdminCP and Mod tools */
 .modTools {

--- a/lib/html.php
+++ b/lib/html.php
@@ -661,6 +661,8 @@ class libHTML
 		// Items not displayed on the menu
 		$links['map.php']=array('name'=>'Map', 'inmenu'=>FALSE);
 		$links['faq.php']=array('name'=>'FAQ', 'inmenu'=>FALSE);
+		$links['contactUs.php']=array('name'=>'Contact Us', 'inmenu'=>FALSE);
+		$links['tournaments.php']=array('name'=>'Tournaments', 'inmenu'=>FALSE);
 		$links['rules.php']=array('name'=>'Rules', 'inmenu'=>FALSE);
 		$links['recentchanges.php']=array('name'=>'Recent changes', 'inmenu'=>FALSE);
 		$links['intro.php']=array('name'=>'Intro', 'inmenu'=>FALSE);

--- a/locales/English/contactUs.php
+++ b/locales/English/contactUs.php
@@ -1,0 +1,54 @@
+<div class="helpPage">
+    <a name="Reporting"></a>
+    <h3 class = "rules"> Contacting a mod/admin:</h3>
+    <div class = "rules_content_show">
+        <h4>Why contact a mod/admin:</h4>
+        <p>
+            Mods can:
+        </p>
+        <ul>
+            <li>Reset your password.</li>
+            <li>Pause/Unpause/Draw games when a player is unavailable to vote.</li>
+            <li>Remove a missing player from a game.</li>
+            <li>Detect cheaters.</li>
+            <li>Ban/unban users, reset user/game invite codes, give/take points, change game settings like phase length, etc.</li>
+        </ul>
+        <p>
+            For these issues use the info below to send reports. For other issues such as bug reports, general questions, etc, you should go elsewhere (e.g. the
+            <a href="/contrib/phpBB3/">forum</a> or the <a href="/contrib/phpBB3/viewforum.php?f=17"> bug reports section</a>).
+        </p>
+        <h4>Where to send</h4>
+        <ul>
+            <li>
+                Email the moderators at <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
+                <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a>, not their personal addresses.<br />
+                A Co-Owner can be contacted at <a href="mailto:<?php print Config::$adminEMail; ?>" class="light"><?php print Config::$adminEMail; ?></a>, if you want to appeal an admin or mod decision.</a>
+            </li>
+        </ul>
+        <h4>What to send</h4>
+        <p>Always try to have some clear reasons when contacting and do not mention it on the forum. In your report/email text you should include:</p>
+        <ul>
+            <li>If making a game request (e.g for a pause or unpause):</li>
+            <ul>
+                <li>
+                Please provide a link to your game or the game name (spelled correctly!)
+                </li>
+                <li>
+                    Please explain why you need a pause, how long you need it for, and the urgency. 
+                </li>
+            </ul>
+            <li>
+                If reporting a cheater:
+                <ul>
+                <li>
+                    Links to the accounts of the players who you suspect.
+                </li>
+                <li>
+                    Link(s) to any specific game(s) that raised your suspicions.
+                </li>
+                </ul>
+            </li>
+        </ul>
+        <p>We will try to reply to you quickly, but be patient: investigations can take quite some time. If a week has gone by please feel free to follow up.</p>
+    </div>
+</div>

--- a/locales/English/credits.php
+++ b/locales/English/credits.php
@@ -30,13 +30,13 @@ defined('IN_CODE') or die('This script can not be run by itself.');
 
 // Get moderator list
 global $DB;
-$query = "SELECT CONCAT('<a href=\"profile.php?userID=',id,'\">',username,'</a>,')
+$query = "SELECT CONCAT('<a href=\"profile.php?userID=',id,'\">',username,'</a>')
 FROM wD_Users WHERE type LIKE '%Moderator%'";
 $tabl = $DB->sql_tabl($query);
 $moderators = '';
 while( list($row) = $DB->tabl_row($tabl) )
 {
-	$moderators .= $row . ' ';
+	$moderators .= $row . ', ';
 }
 
 $credits = array(
@@ -48,57 +48,57 @@ $credits = array(
 	array(
 		'Co-owners of webDiplomacy',
 		'<a href="http://kestas.kuliukas.com/">Kestas Kuliukas</a>, original creator of webDiplomacy<br />
-		<a href="http://www.webdiplomacy.net/profile.php?userID=33599">Zultar</a>'
+		<a href="/profile.php?userID=33599">Zultar</a>'
 	),	
 	array(
-		'The webDiplomacy Moderators, reachable at ' . Config::$modEMail,
+		'The webDiplomacy Moderators, contact at ' . Config::$modEMail,
 		$moderators
 	),
 	array(
 		'The webDiplomacy Developers',
-		'<a href="http://www.webdiplomacy.net/profile.php?userID=15658">jmo1121109</a>, current lead developer<br />
-		<a href="https://www.webdiplomacy.net/profile.php?userID=10">kestasjk</a>'
+		'<a href="/profile.php?userID=15658">jmo1121109</a>, current lead developer<br />
+		<a href="/profile.php?userID=10">kestasjk</a>'
 	),
 	array(
 		'Lifetime Site Contributors',
-		'<a href="https://www.webdiplomacy.net/profile.php?userID=51170">Peregrine Falcon</a>, for his time as a moderator, code contributor, and esteemed member<br />
-		<a href="https://www.webdiplomacy.net/profile.php?userID=4946">abgemacht</a>, for his time as a moderator, administrator, ombudsman, and overseer of the webDip Player Map<br />
-		<a href="https://www.webdiplomacy.net/profile.php?userID=54909">A_Tin_Can</a>, for his time as a moderator and as a leader of site development'
+		'<a href="/profile.php?userID=51170">Peregrine Falcon</a>, for his time as a moderator, code contributor, and esteemed member<br />
+		<a href="/profile.php?userID=4946">abgemacht</a>, for his time as a moderator, administrator, ombudsman, and overseer of the webDip Player Map<br />
+		<a href="/profile.php?userID=54909">A_Tin_Can</a>, for his time as a moderator and as a leader of site development'
 	),
 	array(
 		'Past Developers',
-		'<a href="https://www.webdiplomacy.net/profile.php?userID=54909">A_Tin_Can</a><br />
-		<a href="https://www.webdiplomacy.net/profile.php?userID=382">figlesquidge</a><br />
-		<a href="http://www.webdiplomacy.net/profile.php?userID=3013">thewonderllama</a><br />'
+		'<a href="/profile.php?userID=54909">A_Tin_Can</a><br />
+		<a href="/profile.php?userID=382">figlesquidge</a><br />
+		<a href="/profile.php?userID=3013">thewonderllama</a><br />'
 	),
 	array(
 		'Overseer of the <a id="credits-player-map-a" href="https://www.google.com/maps/d/u/0/viewer?mid=zkz1OHicklqk.ky67Va8gNVi0">webDiplomacy Player Map (external link)</a>',
-		'<a href="http://www.webdiplomacy.net/profile.php?userID=74492">Claesar</a>'
+		'<a href="/profile.php?userID=74492">Claesar</a>'
 	),
 	array(
 		'Creation of the Original Ghost Ratings',
-		'<a href="https://www.webdiplomacy.net/profile.php?userID=2188">TheGhostMaker</a><br />
-		<a href="https://www.webdiplomacy.net/profile.php?userID=13677">Alderian</a>'
+		'<a href="/profile.php?userID=2188">TheGhostMaker</a><br />
+		<a href="/profile.php?userID=13677">Alderian</a>'
 	),
 	array(
 		'Maintenance of the Ghost Ratings List',
-		'<a href="https://www.webdiplomacy.net/profile.php?userID=2188">TheGhostMaker</a><br />
-		<a href="https://www.webdiplomacy.net/profile.php?userID=13677">Alderian</a><br />
-		<a href="https://www.webdiplomacy.net/profile.php?userID=23172">Hellenic Riot</a><br />
-		<a href="https://www.webdiplomacy.net/profile.php?userID=37168">ghug</a>'
+		'<a href="/profile.php?userID=2188">TheGhostMaker</a><br />
+		<a href="/profile.php?userID=13677">Alderian</a><br />
+		<a href="/profile.php?userID=23172">Hellenic Riot</a><br />
+		<a href="/profile.php?userID=37168">ghug</a>'
 	),
 	array(
 		'Past Contributors',
-		'Algis Kuliukas - original database design and maintenance <br />
+		'<strong><u>Algis Kuliukas</u></strong> - original database design and maintenance <br />
 		<a href="http://www.xcelco.on.ca/~ravgames/dipmaps/">Rob Addison</a> - creator of small diplomacy map image <br />
-		Lucas Kruijswijk - authored the DATC adjudicator tests <br />
-		mrlachette, Magilla, arning - pre-0.72 debugging and testing <br />
-		jayp - development of multi-variant code <br />
+		<strong><u>Lucas Kruijswijk</u></strong> - authored the DATC adjudicator tests <br />
+		<strong><u>mrlachette, Magilla, arning</u></strong> - pre-0.72 debugging and testing <br />
+		<strong><u>jayp</u></strong> - development of multi-variant code <br />
 		<a href="http://sourceforge.net/users/fallingrock/">Chris Hughes</a> - webDiplomacy Facebook development, variable phase lengths, game listings pagination <br />
-		Carey Jensen - variant developer, goondip.com developer <br />
-		Alex Lebedev - sponsored the localization support <br />
+		<strong><u>Carey Jensen</u></strong> - variant developer, goondip.com developer <br />
+		<strong><u>Alex Lebedev</u></strong> - sponsored the localization support <br />
 		<a href="https://sourceforge.net/sendmessage.php?touser=1295433">paranoidjpn</a> - Japanese translation, testing, UTF-8 support, developing the small PNG map <br />
-		Oliver Auth - variant creator, owner of vDiplomacy' 
+		<strong><u><a href="/profile.php?userID=18263">Oliver Auth</a></u></strong> - variant creator, owner of <a href="https://vdiplomacy.net">vDiplomacy</a>' 
 	),
 	array(
 		'Miscellaneous',

--- a/locales/English/help.php
+++ b/locales/English/help.php
@@ -29,7 +29,7 @@ print libHTML::pageTitle('webDiplomacy Help and Links','Links to pages with more
 ?>
 <ul class="formlist">
 <li> <strong><u>How to Donate</u></strong> </br>
-webDiplomacy.net is run off of user donations. Because of this, we pledge never to show ads, or charge for webDiplomacy features. </br>
+webDiplomacy.net is run off of user donations. Because of this, we pledge never to show ads, or charge for features.
 If you would like to support the site, click the button below. After submitting a donation, please send an email to a Co-owner at <a href="mailto:<?php print Config::$adminEMail; ?>" class="light"><?php print Config::$adminEMail; ?></a> with your username to receive a donator marker. </br>
 <div style='text-align:left'>
 <form action='https://www.paypal.com/cgi-bin/webscr' method='post'>
@@ -48,8 +48,11 @@ If you would like to mentor a new member please <a href="https://goo.gl/forms/Xd
 Any questions on this program can be directed to webdipmentors@gmail.com.
 </li>
 
-<li><a href="rules.php">Rulebook/Contacting the Mods</a></li>
-<li class="formlistdesc">The webDiplomacy rulebook. Moderator and Co-owner emails.</li>
+<li><a href="rules.php">Rulebook/Moderator Policies</a></li>
+<li class="formlistdesc">The webDiplomacy rulebook. Moderator policies.</li>
+
+<li><a href="contactUs.php">Contacting the Mods</a></li>
+<li class="formlistdesc">Need help? Moderator and Owner emails.</li>
  
 <li><a href="intro.php">The intro to Diplomacy</a></li>
 <li class="formlistdesc">An introduction to playing webDiplomacy. Gives details on unit types, move types, and the basic rules of webDiplomacy.</li>
@@ -60,8 +63,8 @@ Any questions on this program can be directed to webdipmentors@gmail.com.
 <li><a href="profile.php">Find a user</a></li>
 <li class="formlistdesc">Search for a user account registered on this server if you know their user ID number, username, or e-mail address.</li>
 
-<li><a href="recentchanges.php">Recent changes</a></li>
-<li class="formlistdesc">Recent changes to the webDiplomacy software.</li>
+<li><a href="tournaments.php">Tournaments</a></li>
+<li class="formlistdesc">Tournament and Special Game rules and how to start one.</li>
 
 <li><a href="halloffame.php">Hall of fame</a></li>
 <li class="formlistdesc">The pros of this server; the top 100 by points!</li>
@@ -92,6 +95,9 @@ Any questions on this program can be directed to webdipmentors@gmail.com.
 
 <li><a href="AGPL.txt">GNU Affero General License</a></li>
 <li class="formlistdesc">The OSI approved license which applies to the vast majority of webDiplomacy.</li>
+
+<li><a href="recentchanges.php">Recent changes</a></li>
+<li class="formlistdesc">Recent changes to the webDiplomacy software.</li>
 
 </ul>
 

--- a/locales/English/rules.php
+++ b/locales/English/rules.php
@@ -1,344 +1,263 @@
-<style type="text/css">
-#rulebook p {
-color:#444;
-font-weight:normal;
-margin-bottom:30px;
-margin-left:40px;
-margin-right:20px;
-padding-left:10px;
-}
-#rulebook p.notext {
-border:0;
-color:black;
-}
-#rulebook em {
-text-decoration:underline;
-font-style:normal;
-}
-#rulebook ul {
-	margin-left:40px;
-	color:#666;
-}
-#rulebook ol {
-	margin-left:40px;
-	color:#666;
-#rulebook p {
-	margin-bottom:0;
-}
-#rulebook h4 {
-	margin-left:30px;
-}
-</style>
+<div class="helpPage">
+   <p class="rules" style="text-align:center;">
+    <strong>Sections: </br>  </strong>
+    <a href="#Site Rules">Site Rules</a>
+      - <a href="#Forum Rules">Forum Rules</a>
+      - <a href="#ModPolicies">Moderator Policies</a>
+   </p>
 
-<div id="rulebook">
-<p class="notice notext">
-<a href="#Site Rules">Site Rules</a>
-- <a href="#Forum Rules">Forum Rules</a>
-- <a href="#ModPolicies">Moderator Policies</a>
-- <a href="#Tournaments">Tournaments</a>
-- <a href="#Reporting">Contacting a mod/admin</a>
-</p>
+   <!-- Site Rules -->
+   <a name="Site Rules"></a>
+   <h3 class = "rules"> Site Rules (Click a rule to expand)</h3>
+   <div name="MultiAccounting" class = "rules_title">1. No Multi-Accounting</div> 
+   <div class = "rules_content">
+      <p>
+         You may only have one account, second accounts are not allowed under any circumstances, and will be banned. This may also lead to your first account also being banned. If you forget your password, use the lost password finder <a class="light" href="logon.php?forgotPassword=1">here</a>. If you are still unable to log in, contact the mods.
+      </p>
+   </div>
+   <div name="MetaGaming" class = "rules_title">2. No Meta-gaming</div>
+   <div class = "rules_content">
+      <p>
+         You cannot play a public game with players that you know outside of the site. In doing so, you create an unfair environment for other players by giving yourself the opportunity to form alliances for reasons outside the game. This includes playing public games with family, friends, relatives, coworkers, or even joining a game with any player of a previous game with a predetermined intent to ally with or attack certain players. Additionally, you cannot make deals based on any factors outside of the game.
+         <br /><br />
+         Because Diplomacy is a social game, we always encourage playing with friends. However, you should always do so in a private, password-protected game and make sure that every player knows about any real life connections before the game begins.
+      </p>
+   </div>
+   <div name="Press" class = "rules_title">3. Don't break game messaging/press rules.</div>
+   <div class = "rules_content">
+      <p>
+         If you enter a game with limited press/messaging (such as global-only) then you can't use other methods such as the forum, email, or PM to bypass this.
+         <br /><br />
+         If you are playing in a gunboat (no press/anon game) do not post anything about your game in the forum and refrain from posting in any threads you feel might be referencing your game. 
+         <br /><br />
+         Using the Pause or Cancel buttons as signals to other players is violating the press rules. For example, voting pause to signal the desire for a smaller draw is not allowed. If you need a pause in a gunboat game contact the moderators (see below for the contact details) and explain why. 
+         <br /><br />
+         Posting in the forum about an ongoing gunboat (no press) game or a limited press game is not allowed for anyone. This includes offering advice to game participants or predicting the outcome of a game. All questions about a gunboat game must wait until the game is completed.  
+      </p>
+   </div>
+   <div name="Press Rules" class = "rules_title">4. Keep press appropriate.</div>
+   <div class = "rules_content">
+      <p>
+         Diplomacy is a game of many strategies and your discussions with other players can sometimes be hostile, impolite, and even uncivilized. These press strategies are all permissible on webDiplomacy and in Diplomacy in general. However, your press with other players should never include the following:
+         </br></br>
+         -Messages of sexual nature</br>
+         -Overt racism or sexism of any kind</br>
+         -Doxxing (revealing any real life information) of another player</br>
+         </br>
+         This rule also applies to game titles.
+         </br></br>
+         First offenses will result in a warning in some circumstances but may result in a severe point dock and removal from the game in question if the offense necessitates such action. Second offenses may result in a temporary or permanent ban from webDiplomacy.
+      </p>
+   </div>
+   <div name="Mods" class = "rules_title">5. Do not use the software or moderators as a diplomacy tactic</div>
+   <div class = "rules_content">
+      <p>
+         Lying is fine in Diplomacy except when it gives mods/admins unnecessary work to do!<br /><br />
+         Falsely accusing someone of being a multi-accounter/meta-gaming to rally others against them in a game, or claiming that your orders didn't
+         come out the way you entered them to cover up your motives, means mods/admins spend time looking for cheaters/bugs which were made up.<br /><br />
+         All accusations against other players must be made directly to the mod/admin team directly as specified below, in private, for this reason, and software bug claims
+         must be genuine, even if only told to another player. Avoid making cheating accusations in game, via pm, or on the forum. 
+      </p>
+   </div>
+   <div name="Pause" class = "rules_title">6. The Pause/Unpause feature is not a diplomatic tool</div>
+   <div class = "rules_content">
+      <p>
+         The pause is there to stop players from missing their orders, but is not part of the game.&nbsp; As such pausing or unpausing should not be used for diplomatic gain, such as refusing to unpause unless other players will draw the game.&nbsp; If it is being abused staff may step in to sort it out.
+         <Br /><br />
+         The pause button cannot be used as a diplomatic tool and should not be used for anything other than indicating the need for a pause. If you need a pause in a gunboat game that was not agreed upon before the game, email the moderators before voting to pause. The moderators will post in the global press asking for a pause. The other players are not obligated to pause in this situation, and force pauses will not be granted except in emergency situations until the moderators can find someone to watch your account. Please try to plan ahead and avoid the need for pauses if possible.
+      </p>
+   </div>
+   <div name="Account" class = "rules_title">7. You may not access another player's account without permission</div>
+   <div class = "rules_content">
+      <p>
+         In general, account sitting (getting someone you trust to log on as you and issue orders when you are unable to) is encouraged.&nbsp; However, you must not get a sitter or sit for somebody you share games with. Also, anything done by the sitter whilst on your account is your responsibility, so make sure you're happy with that before you give them your password.<br />
+         It is also your responsibility to change your password after allowing someone to use your account.
+      </p>
+   </div>
+   <div name="Spam" class = "rules_title">8. Do not spam the forum or private messaging system</div>
+   <div class = "rules_content">
+      <p>
+         You are welcome and indeed encouraged to join in with the community but be sensible. Try to keep replies relevant to the conversation and don't start too many threads at once. Before posting a question relating to the software please read the <a href="faq.php" class="light">FAQ</a>.
+      </p>
+   </div>
+   <div name="Answer" class = "rules_title">9. You must answer communication from site staff</div>
+   <div class = "rules_content">
+      <p>
+         You must answer any warnings or other messages sent to you by the moderators, because if you don't reply it will be assumed you have something to hide, and your account may be closed.&nbsp; As part of this, you must make sure that the email address provided is one you still check, because this normally how staff will communicate with you.
+      </p>
+   </div>
+   <div name="CommonSense" class = "rules_title">10. Follow common sense</div>
+   <div class = "rules_content">
+      <p>
+         The rules above are mainly ones which might not be obvious; just because a specific rule isn't given here doesn't mean
+         moderators can't stop people ruining the server for others!
+      </p>
+   </div>
+   <!-- End Site Rules -->
 
-<div class="hr"></div>
+   <!-- Forum Rules -->
+   <a name="Forum Rules"></a>
+   <h3 class = "rules"> Forum Rules (Click a rule to expand)</h3>
+   <div name="Personal Threats" class = "rules_title">1. Do not make personal threats</div>
+   <div class = "rules_content">
+      <p>
+         This is a Diplomacy site, and no members should ever have to worry about actions being taken against them in real life. The forum will always remain a fun and welcoming part of webDiplomacy where discussion is encouraged, and it should always be safe for members who participate and post in it.
+      </p>
+   </div>
+   <div name="Harassment" class = "rules_title">2. No abusive, bigoted, or degrading content</div>
+   <div class = "rules_content">
+      <p>
+         Creating threads or posting replies that target a member, group of members, or group of people is prohibited. While some discussions on our forum can become heated, attacking another member is not permitted on the forum. Players who post a reply in a discussion attacking another player may be warned and/or silenced depending on the severity of the offence. Consistently harassing another player or going out of one’s way to attack another player, instead of contributing to discussion, may also classify as grounds for a silence or further action depending on the surrounding circumstances. 
+         <br></br>
+         Likewise, bigotry toward another member or a group of people is not permitted. Our site hosts players from around the world and is intended to be a welcoming and open place for all. Sexism, racism, homophobia, and other forms of bigotry both hamper discussion and also threaten our reputation; as a result, they carry only negative consequences for our site. We will take a zero tolerance approach to any examples of such behaviour. 
+      </p>
+   </div>
+   <div name="Doxxing" class = "rules_title">3. Do not reference to another member’s personal information</div>
+   <div class = "rules_content">
+      <p>
+         Each and every member has a right to privacy and to remain as anonymous as they wish. As such, posting any personal information of another member, including but not limited to: their name, address, picture, phone number, email, social media information, etc., or making reference to their personal information is prohibited. 
+         <br></br>
+         Of course, you are welcome to post as much or as little of your own personal information on our forum. Please be aware that our forum is public and can be viewed even by those who do not own an account and are not logged in. Once you hit “post,” your post will not be deleted.
+      </p>
+   </div>
+   <div name="Forum Spam" class = "rules_title">4. Do not spam the forum</div>
+   <div class = "rules_content">
+      <p>
+         Posting multiple threads on the same topic, advertising an irrelevant product or service, posting threads in order to help another user bypass a forum silence, reposting threads that have been silenced, and posting appeals of moderator decisions on behalf of oneself or on behalf of other players on the forum all classify as spam. Please try to keep replies to a thread relevant to the intended topic of discussion and please do not start too many threads at once. Using self-restraint is critical. 
+         <br></br>
+         Please consult the <a href="faq.php" class="light">FAQ</a> before posting a question relating to the site’s software. 
+      </p>
+   </div>
+   <div name="Circumventing Press Restrictions" class = "rules_title">5. Do not break press rules</div>
+   <div class = "rules_content">
+      <p>
+         Because press in gunboat games, rulebook press games, and public press games is restricted, discussing them on the forum while they are being played can jeopardise the fairness of the game and, if done by a player in the game, can classify as working around press restrictions. Even in an effort to draw or cancel a game, posting about an ongoing gunboat game is prohibited. If a player is stalemated and refuses to draw or refuses to unpause a paused game, please email the moderators at <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
+         <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a>. 
+      </p>
+   </div>
+   <div name="Cheating Accusations" class = "rules_title">6. Do not make public cheating accusations</div>
+   <div class = "rules_content">
+      <p>
+         Cheating accusations should not be made publicly on the forums, in games, or via PM. Instead, reports of potential cheating should be sent directly to the moderators at <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
+         <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> with a specific summary of the situation and the players you believe are working around the rules. 
+      </p>
+   </div>
+   <div name="Self Moderation" class = "rules_title">7. Exercise self-moderation and use your common sense</div>
+   <div class = "rules_content">
+      <p>
+         While the moderators reserve the right to take an active role in forum moderation, we are not babysitters, and our priorities are catching cheaters and making webDiplomacy the best Diplomacy site around. As such, a user-driven approach is generally recommended to forum moderation:
+      </p>
+      <ul>
+         <li>You can mute any other user that you do not want to see in the forum or receive PMs from.</li>
+         <li>You can mute any forum thread that you aren’t interested in or do not wish to contribute to.</li>
+         <li>You can participate on our forum constructively instead of aggressively.</li>
+         <li>You can be as open or restrictive about the content that you see as you like.</li>
+      </ul>
+      <p>
+         While a user-driven approach to moderation is generally sufficient, the moderators will step in as they believe is necessary in accordance with these rules.
+      </p>
+   </div>
+   <div name="Evading Silences" class = "rules_title">8. Do not evade silences</div>
+   <div class = "rules_content">
+      <p>
+         Silences are a last resort for forum moderation and should not be worked around. If a thread has been silenced, do not create a new one to follow on from where it left off. If a thread had gone off topic before the silence, you may request permission from a moderator to start a new one with the original topic. 
+         <br></br>
+         If another user has been silenced then you may not work around their silence by posting messages for them. Silences are designed to force users to cool off; allowing them to post via proxy negates that. 
+         <br></br>
+         If you have been silenced, you must wait out your silence. Evading a silence via creating a new account would be a violation of the multi-accounting rule and would likely result in your ban from the site.
+      </p>
+   </div>
+   <div name="Grey Areas" class = "rules_title">9. These rules are not exhaustive</div>
+   <div class = "rules_content">
+      <p>
+         The moderators reserve the right to lock or silence any thread or user that is consistently breaking any of these rules or otherwise disrupting the regular flow of the site on the forum. The webDiplomacy community at large is always our utmost concern and we may have to take action in certain scenarios that are not covered by these rules. Furthermore, all forum rules also apply to PM's or any other form of communication on the site.
+         <br></br>
+         The forum is intended to be fun and open, but that ultimately depends on what you make of it. By following these rules, the forum should operate smoothly, but in the end, that responsibility falls to all of the members of webDiplomacy.
+      </p>
+   </div>
+   <!-- End Forum Rules -->
 
-<a name="Site Rules"></a><h3> Site Rules</h3>
-<a name="MultiAccounting"></a><h4>1. No Multi-Accounting</h4>
-<p>
-  You may only have one account, second accounts are not allowed under any circumstances, and will be banned. This may also lead to your first account also being banned.&nbsp; If you forget your password, use the lost password finder <a class="light" href="logon.php?forgotPassword=1">here</a>. If you are still unable to log in, contact the mods.
-</p>
+   <a name="Forum Moderation"></a>
+   <h3 class = "rules"> Forum Moderation:</h3>
+   <div class = "rules_content_show">
+      <p>
+         While the moderators always exercise appropriate discretion and discuss various options with one another prior to acting, there are sometimes no other options than to take immediate action on the forum. The moderators retain the right to issue varying penalties including shorter or longer silences based on the severity of the offence. 
+         <br></br>
+         Upon a first offence, a user will either receive an official warning OR a 48 hour silence. Subsequent offences may result in further and lengthier silences. Constant or more severe rule infractions could result in harsher penalties at the discretion of the site moderators and the site owners. The moderators will record each action taken on the forum with an email to the offending user’s registered email. As usual, any moderator action taken against you can be appealed by emailing <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
+         <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> and the results of that appeal are final. 
+      </p>
+      <a name="Silences"></a>
+      <h4> Silences</h4>
+      <ul>
+         <li>Silences can apply to a user or a thread.</li>
+         <li>The details can be viewed on the forum page, when the "New thread" button is pressed.</li>
+         <li>Thread silences last indefinitely, but user silences expire after a brief cool-off period.</li>
+         <li>Silenced threads / users can still be viewed, however no more messages may be posted.</li>
+         <li>Silenced users can still play in games; a silence only affects the forum and pm's.</li>
+      </ul>
+      <p>
+         When in doubt about whether posting something is allowed, remember your first responsibility is to use common sense and respect other players.
+      </p>
+   </div>
 
-<a name="MetaGaming"></a><h4>2. No Meta-gaming</h4>
-<p>
-  You cannot play a public game with players that you know outside of the site. In doing so, you create an unfair environment for other players by giving yourself the opportunity to form alliances for reasons outside the game. This includes playing public games with family, friends, relatives, coworkers, or even joining a game with any player of a previous game with a predetermined intent to ally with or attack certain players. Additionally, you cannot make deals based on any factors outside of the game.
-<br /><br />
-Because Diplomacy is a social game, we always encourage playing with friends. However, you should always do so in a private, password-protected game and make sure that every player knows about any real life connections before the game begins.
-</p>
+   <a name="ModPolicies"></a>
+   <h3 class = "rules"> Moderator Policies (Click a policy to expand)</h3>
+   <div class = "rules_title">Cancelling games</div>
+   <div class = "rules_content">
+      <p>
+         We will consider cancelling games when there are two or more cheaters in the same game. We will encourage the remaining players to cancel on their own at the conclusion of an investigation; and give them 24 hours to do so before doing it ourselves.
+      </p>
+   </div>
+   <div class = "rules_title">Pausing/Unpausing Games</div>
+   <div class = "rules_content">
+      <p>
+         The players should take care of this themselves as much as they can. If they have agreed to pause, then they should have agreed when to unpause. If the unpause doesn't happen by said date, then they can email us and we will look into it. 
+         <br></br>
+         If a player has to leave at short notice then they may email us and we will pause the game for them - however, if anyone objects to such a pause then we will unpause the game, and let the requester know. This is also how pauses should be requested in limited press games where they cannot be otherwise arranged.
+      </p>
+   </div>
+   <div class = "rules_title">Drawing Games</div>
+   <div class = "rules_content">
+      <p>
+         We do not draw any games due to cheating. We will only force games to draw if they have been at a stalemate for at least two years with no SC's changing hands and no possible sign of a breakthrough. If alerted to such a scenario; we will email the player(s) holding the game up and ask them how they plan to break through. If we deem their plan to be unrealistic, or it includes hoping for misorders or for players to miss phases, then we may force a game to draw.
+      </p>
+   </div>
+   <div class = "rules_title">Appealing decisions</div>
+   <div class = "rules_content">
+      <p>
+         As users have their own set of responsibilities, so does the moderator staff. As representatives of the 
+         WebDiplomacy users, the moderators will be held accountable for disciplinary decisions. While judgement 
+         regarding forum rule violations remains at the sole discretion of the moderator staff, users will be provided 
+         with a clear warning regarding rules violations in either a forum post or private message. Users can appeal 
+         any moderator's decision by sending an email to <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
+         <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> specifying the grounds for the appeal. 
+         The appeal will be dealt with by one of the admins who was not involved in the original decision or by the 
+         site owner. Appeals made on behalf of other members will not be considered. The outcome of an appeal is final. 
+         <br><br>
+         Please keep all appeals to email. When multiple forum threads are made about a moderation decision the resulting confusion becomes a frustration for members and moderators alike.
+         There may be a formal explanation and discussion on moderator decisions in the forum, but the moderator staff will never disclose information that may contain personal information about members or about the methods used to enforce the rules.
+         In situations where multiple threads are opened on a specific topic the site administrators may close the duplicate threads and open an official thread to 
+         explain the issue and give the final determination on the appeal.
+         <br><br>
+         See our <a href='contactUs.php' class='light'>contact us</a> page for more on mod and admin contact details.
+      </p>
+   </div>
 
-<a name="Press"></a><h4>3. Don't work around game messaging/press rules.</h4>
-<p>
-  If you enter a game with limited press/messaging (such as global-only) then you can't use other methods such as the forum, email, or PM to bypass this.
-<br /><br />
-  If you are playing in a gunboat (no press/anon game) do not post anything about your game in the forum and refrain from posting in any threads you feel might be referencing your game. 
-<br /><br />
-Using the Pause or Cancel buttons as signals to other players is violating the press rules. For example, voting pause to signal the desire for a smaller draw is not allowed. If you need a pause in a gunboat game contact the moderators (see below for the contact details) and explain why. 
-<br /><br />
-Posting in the forum about an ongoing gunboat (no press) game or a limited press game is not allowed for anyone. This includes offering advice to game participants or predicting the outcome of a game. All questions about a gunboat game must wait until the game is completed.  
-</p>
-
-<a name="Press Rules"></a><h4>4. Keep press appropriate.</h4>
-<p>
-Diplomacy is a game of many strategies and your discussions with other players can sometimes be hostile, impolite, and even uncivilized. These press strategies are all permissible on webDiplomacy and in Diplomacy in general. However, your press with other players should never include the following:
-</br></br>
--Messages of sexual nature</br>
--Overt racism or sexism of any kind</br>
--Doxxing (revealing any real life information) of another player</br>
-</br>
-This rule also applies to game titles.
-</br></br>
-First offenses will result in a warning in some circumstances but may result in a severe point dock and removal from the game in question if the offense necessitates such action. Second offenses may result in a temporary or permanent ban from webDiplomacy.
-</p>
-
-<a name="Mods"></a><h4>5. Do not use the software or moderators as a diplomacy tactic</h4>
-<p>
-  Lying is fine in Diplomacy except when it gives mods/admins unnecessary work to do!<br /><br />
-  Falsely accusing someone of being a multi-accounter/meta-gaming to rally others against them in a game, or claiming that your orders didn't
-  come out the way you entered them to cover up your motives, means mods/admins spend time looking for cheaters/bugs which were made up.<br /><br />
-
-  All accusations against other players must be made directly to the mod/admin team directly as specified below, in private, for this reason, and software bug claims
-  must be genuine, even if only told to another player. Avoid making cheating accusations in game, via pm, or on the forum. 
-</p>
-
-<a name="Pause"></a><h4>6. The Pause/Unpause feature is not a diplomatic tool</h4>
-<p>
-  The pause is there to stop players from missing their orders, but is not part of the game.&nbsp; As such pausing or unpausing should not be used for diplomatic gain, such as refusing to unpause unless other players will draw the game.&nbsp; If it is being abused staff may step in to sort it out.
-  <Br /><br />
-The pause button cannot be used as a diplomatic tool and should not be used for anything other than indicating the need for a pause. If you need a pause in a gunboat game that was not agreed upon before the game, email the moderators before voting to pause. The moderators will post in the global press asking for a pause. The other players are not obligated to pause in this situation, and force pauses will not be granted except in emergency situations until the moderators can find someone to watch your account. Please try to plan ahead and avoid the need for pauses if possible.
-</p>
-
-<a name="Account"></a><h4>7. You may not access another player's account without permission</h4>
-<p>
-  In general, account sitting (getting someone you trust to log on as you and issue orders when you are unable to) is encouraged.&nbsp; However, you must not get a sitter or sit for somebody you share games with. Also, anything done by the sitter whilst on your account is your responsibility, so make sure you're happy with that before you give them your password.<br />
-  It is also your responsibility to change your password after allowing someone to use your account.
-</p>
-
-<h4><a name="Spam"></a>8. Do not spam the forum or private messaging system</h4>
-<p>
-  You are welcome and indeed encouraged to join in with the community but be sensible.&nbsp; Try to keep replies relevant to the conversation and don't start too many threads at once. Before posting a question relating to the software please read the <a href="faq.php" class="light">FAQ</a>.
-</p>
-
-<a name="Answer"></a><h4>9. You must answer communication from site staff</h4>
-<p>
-  You must answer any warnings or other messages sent to you by the moderators, because if you don't reply it will be assumed you have something to hide, and your account may be closed.&nbsp; As part of this, you must make sure that the email address provided is one you still check, because this normally how staff will communicate with you.
-</p>
-
-<a name="CommonSense"></a><h4>10. Follow common sense</h4>
-<p>
-  The rules above are mainly ones which might not be obvious; just because a specific rule isn't given here doesn't mean
-  moderators can't stop people ruining the server for others!
-</p>
-
-<div class="hr"></div>
-
-<a name="Forum Rules"></a><h3> Forum Rules</h3>
-<a name="Personal Threats"></a><h4>1. Do not make personal threats on the forum</h4>
-<p>
- This is a Diplomacy site, and no members should ever have to worry about actions being taken against them in real life. The forum will always remain a fun and welcoming part of webDiplomacy where discussion is encouraged, and it should always be safe for members who participate and post in it.
-</p>
-<a name="Harassment"></a><h4>2. Do not make threads or posts that are abusive or degrading toward another member, group of members, or other groups of people.</h4>
-<p>
-  Creating threads or posting replies that target a member, group of members, or group of people is prohibited. While some discussions on our forum can become heated, attacking another member is not permitted on the forum. Players who post a reply in a discussion attacking another player may be warned and/or silenced depending on the severity of the offence. Consistently harassing another player or going out of one’s way to attack another player, instead of contributing to discussion, may also classify as grounds for a silence or further action depending on the surrounding circumstances. 
-<br></br>
-Likewise, bigotry toward another member or a group of people is not permitted. Our site hosts players from around the world and is intended to be a welcoming and open place for all. Sexism, racism, homophobia, and other forms of bigotry both hamper discussion and also threaten our reputation; as a result, they carry only negative consequences for our site. We will take a zero tolerance approach to any examples of such behaviour. 
-</p>
-
-<a name="Doxxing"></a><h4>3. Do not post or make reference to another member’s personal information</h4>
-<p>
-  Each and every member has a right to privacy and to remain as anonymous as they wish. As such, posting any personal information of another member, including but not limited to: their name, address, picture, phone number, email, social media information, etc., or making reference to their personal information is prohibited. 
-<br></br>
-Of course, you are welcome to post as much or as little of your own personal information on our forum. Please be aware that our forum is public and can be viewed even by those who do not own an account and are not logged in. Once you hit “post,” your post will not be deleted.
-</p>
-
-<a name="Forum Spam"></a><h4>4. Do not spam the forum</h4>
-<p>
-  Posting multiple threads on the same topic, advertising an irrelevant product or service, posting threads in order to help another user bypass a forum silence, reposting threads that have been silenced, and posting appeals of moderator decisions on behalf of oneself or on behalf of other players on the forum all classify as spam. Please try to keep replies to a thread relevant to the intended topic of discussion and please do not start too many threads at once. Using self-restraint is critical. 
-<br></br>
-Please consult the <a href="faq.php" class="light">FAQ</a> before posting a question relating to the site’s software. 
-
-</p>
-
-<a name="Circumventing Press Restrictions"></a><h4>5. Do not attempt to circumvent press restrictions</h4>
-<p>
-  Because press in gunboat games, rulebook press games, and public press games is restricted, discussing them on the forum while they are being played can jeopardise the fairness of the game and, if done by a player in the game, can classify as working around press restrictions. Even in an effort to draw or cancel a game, posting about an ongoing gunboat game is prohibited. If a player is stalemated and refuses to draw or refuses to unpause a paused game, please email the moderators at <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
-  <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a>. 
-</p>
-
-<a name="Cheating Accusations"></a><h4>6. Do not make public cheating accusations</h4>
-<p>
-  Cheating accusations should not be made publicly on the forums, in games, or via PM. Instead, reports of potential cheating should be sent directly to the moderators at <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
-  <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> with a specific summary of the situation and the players you believe are working around the rules. 
-</p>
-
-<a name="Self Moderation"></a><h4>7. Exercise self-moderation and use your common sense</h4>
-<p>
-While the moderators reserve the right to take an active role in forum moderation, we are not babysitters, and our priorities are catching cheaters and making webDiplomacy the best Diplomacy site around. As such, a user-driven approach is generally recommended to forum moderation:
-</p>
-<ul>
-<li>You can mute any other user that you do not want to see in the forum or receive PMs from.</li>
-<li>You can mute any forum thread that you aren’t interested in or do not wish to contribute to.</li>
-<li>You can participate on our forum constructively instead of aggressively.</li>
-<li>You can be as open or restrictive about the content that you see as you like.</li>
-</ul>
-<p>
-While a user-driven approach to moderation is generally sufficient, the moderators will step in as they believe is necessary in accordance with these rules.
-</p>
-
-<a name="Evading Silences"></a><h4>8. Do not evade silences</h4>
-<p>
-  Silences are a last resort for forum moderation and should not be worked around. If a thread has been silenced, do not create a new one to follow on from where it left off. If a thread had gone off topic before the silence, you may request permission from a moderator to start a new one with the original topic. 
-<br></br>
-If another user has been silenced then you may not work around their silence by posting messages for them. Silences are designed to force users to cool off; allowing them to post via proxy negates that. 
-<br></br>
-If you have been silenced, you must wait out your silence. Evading a silence via creating a new account would be a violation of the multi-accounting rule and would likely result in your ban from the site.
-</p>
-
-<a name="Grey Areas"></a><h4>9. These rules are not exhaustive</h4>
-<p>
-  The moderators reserve the right to lock or silence any thread or user that is consistently breaking any of these rules or otherwise disrupting the regular flow of the site on the forum. The webDiplomacy community at large is always our utmost concern and we may have to take action in certain scenarios that are not covered by these rules. Furthermore, all forum rules also apply to PM's or any other form of communication on the site.
-  <br></br>
-  The forum is intended to be fun and open, but that ultimately depends on what you make of it. By following these rules, the forum should operate smoothly, but in the end, that responsibility falls to all of the members of webDiplomacy.
-</p>
-
-<a name="Forum Moderation"></a><h3> Forum Moderation:</h3>
-
-
-<p>
-While the moderators always exercise appropriate discretion and discuss various options with one another prior to acting, there are sometimes no other options than to take immediate action on the forum. The moderators retain the right to issue varying penalties including shorter or longer silences based on the severity of the offence. 
-<br></br>
-Upon a first offence, a user will either receive an official warning OR a 48 hour silence. Subsequent offences may result in further and lengthier silences. Constant or more severe rule infractions could result in harsher penalties at the discretion of the site moderators and the site owners. The moderators will record each action taken on the forum with an email to the offending user’s registered email. As usual, any moderator action taken against you can be appealed by emailing <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
-  <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> and the results of that appeal are final. 
-</p>
-
-<a name="Silences"></a><h4> Silences</h4>
-<ul>
-<li>Silences can apply to a user or a thread.</li>
-<li>The details can be viewed on the forum page, when the "New thread" button is pressed.</li>
-<li>Thread silences last indefinitely, but user silences expire after a brief cool-off period.</li>
-<li>Silenced threads / users can still be viewed, however no more messages may be posted.</li>
-<li>Silenced users can still play in games; a silence only affects the forum and pm's.</li>
-</ul>
-<p>
-When in doubt about whether posting something is allowed, remember your first responsibility is to use common sense and respect other players.
-</p>
-
-<div class="hr"></div>
-
-<a name="ModPolicies"></a><h3> Moderator Policies:</h3>
-<h4>Cancelling games</h4>
-<p>
-  We will consider cancelling games when there are two or more cheaters in the same game. We will encourage the remaining players to cancel on their own at the conclusion of an investigation; and give them 24 hours to do so before doing it ourselves.
-</p>
-<h4>Pausing/Unpausing Games</h4>
-<p>
-The players should take care of this themselves as much as they can. If they have agreed to pause, then they should have agreed when to unpause. If the unpause doesn't happen by said date, then they can email us and we will look into it. 
-<br></br>
-If a player has to leave at short notice then they may email us and we will pause the game for them - however, if anyone objects to such a pause then we will unpause the game, and let the requester know. This is also how pauses should be requested in limited press games where they cannot be otherwise arranged.
-</p>
-<h4>Drawing Games</h4>
-<p>
-We do not draw any games due to cheating. We will only force games to draw if they have been at a stalemate for at least two years with no SC's changing hands and no possible sign of a breakthrough. If alerted to such a scenario; we will email the player(s) holding the game up and ask them how they plan to break through. If we deem their plan to be unrealistic, or it includes hoping for misorders or for players to miss phases, then we may force a game to draw.
-</p>
-<h4>Appealing decisions</h4>
-<p>
-As users have their own set of responsibilities, so does the moderator staff. As representatives of the 
-WebDiplomacy users, the moderators will be held accountable for disciplinary decisions. While judgement 
-regarding forum rule violations remains at the sole discretion of the moderator staff, users will be provided 
-with a clear warning regarding rules violations in either a forum post or private message. Users can appeal 
-any moderator's decision by sending an email to <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
-  <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> specifying the grounds for the appeal. 
-The appeal will be dealt with by one of the admins who was not involved in the original decision or by the 
-site owner. Appeals made on behalf of other members will not be considered. The outcome of an appeal is final. 
-<br><br>
-Please keep all appeals to email. When multiple forum threads are made about a moderation decision the resulting confusion becomes a frustration for members and moderators alike.
-There may be a formal explanation and discussion on moderator decisions in the forum, but the moderator staff will never disclose information that may contain personal information about members or about the methods used to enforce the rules.
-In situations where multiple threads are opened on a specific topic the site administrators may close the duplicate threads and open an official thread to 
-explain the issue and give the final determination on the appeal.
-<br><br>
-See below for more on mod and admin contact details.
-</p>
-
-<div class="hr"></div>
-
-<a name="Tournaments"></a><h3> Tournaments &amp; Feature games:</h3>
-<p>There are two types of special games on the site. If you're interested in starting or running either type please email the mod team (see the contact details below) and explain your idea to the moderator team. </p>
-
-<h4>1. Feature Games</h4>
-<p>
-These are special rule games like Chainsaw diplomacy, Pacifist diplomacy, or School of War games. They may involve violating some site rules so a predefined set of rules must be agreed upon by every participant. 
-</p>
-<ul>
-<li>No more than 14 players (exception being a world game)</li>
-<li>May require shuffling players by the moderator team</li>
-<li>Must email <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
-  <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> for quick approval, this email should include participants, pause agreements (if any), end game requirements (if any), and alteration to press rules (if any).</li> 
-</ul>
-
-<h4>2. Tournaments</h4>
-<p>
-These are larger series of games with unique scoring rules to determine a winner. These games will have a Tournament Director (TD), who will oversee all aspects of the tournament. This person will be responsible for making decisions relating to the scoring, pauses, and anything affecting game play. 
-</p>
-<ul>
-<li>Potential TD's must request approval *before* advertising. The moderator team reserves the right to deny tournaments or tournament directors.</li>
-<li>TD's must include a set of rules for potential participants to agree upon, that all participants must agree too. Mid-Tournament rule changes are discouraged and require new permission from the moderator team.</li>
-<li>The moderator team will enforce site-wide rules in tournaments as they do other games.</li>
-<li>Discussion related to your or other players' usernames, as well as other potentially identifying information is strictly forbidden in all anonymous tournament games.</li>
-<li>All press and negotiations must take place within game chat in all anonymous tournament games.</li>
-<li>Players within tournaments must accept that the TD moderates their own tournament decisions. Please choose which tournaments to join carefully.</li>
-<li>TD's may not play in their own tournaments.</li>
-<li>TD's may utilize WFO (Wait for Orders) mode to prevent NMR's in games.</li>
-<li>TD's may request the list and position of players in their tournament even in anonymous games.</li> 
-<li>TD's may request the moderator team pm or email any player with questions or warnings regarding the tournament. </li>
-<li>TD's may request a message be posted in every games public messaging, including anon games, to remind participants of tournament rules or for tournament scoring updates.</li>
-<li>As with all mod/admin decisions if you disagree with a TD's decision you can appeal it directly to an admin or owner. See below for the mod/admin contact details.</li>
-</ul>
-<p>Please e-mail the mod/admin team at <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
-  <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> if you want to start a tournament (see the contact details below), and you will be asked to fill out an application form that will help us set the tournament up.</p>
-
-<div class="hr"></div>
-
-<a name="Reporting"></a><h3> Contacting a mod/admin:</h3>
-
-<h4>Why contact a mod/admin:</h4>
-<p>
-Mods can:</p>
-
-<ul><li>Pause/Unpause/Draw games when a player is unavailable to vote.</li>
-<li>Access months of server logs and the software to detect/analyze possible multi-accounters based on a range of criteria.</li>
-<li>Ban/unban users, reset user/game passwords, give/take points, change game settings like phase length, etc.</li>
-</ul>
-<p>
-For these issues use the info below to send reports. For other issues such as bug reports, general questions, etc, you should go elsewhere (e.g. the
-<a href="forum.php" class="light">built-in forum</a> or the <a href="http://forum.webdiplomacy.net/" class="light">
-developer forum</a>).</p>
-
-<h4>Where to send</h4>
-<ul>
-<li>
-  Email the moderators at <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
-  <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a>, not their personal addresses.<br />
-  A Co-Owner can be contacted at <a href="mailto:<?php print Config::$adminEMail; ?>" class="light"><?php print Config::$adminEMail; ?></a>, if you want to appeal an admin or mod decision.</a>
-</li>
-</ul>
-
-<h4>What to send</h4>
-<p>Always try to have some clear reasons when contacting and do not mention it on the forum. In your report/email text you should include:
-</p><ul>
-	<li>If making a general request (e.g for an unpause):</li>
-	<ul><li>
-	Ensure that you make the subject line useful (e.g. "Unpausing help" or "Phaselength change") so we know we can quickly deal with it in a spare moment - if you don't it might not be solved for some time.</li>
-	<li>In cases such as drawing/pausing a game, standard practice is to check the global chat of the game before acting, so please get other players to post their agreement.<br />
-	You don't necessarily need everyone to agree, and we will post back into the global chat when we change these settings letting you know.</li>
-	</ul>
-	<li>If reporting a multi-accounter:
-	<ul>
-    <li>
-      Links to the accounts of the players who you suspect.
-    </li>
-    <li>
-      Link(s) to any specific game(s) that raised your suspicions.
-    </li>
-    <li>
-      Any relevant information that you have noticed.
-    </li>
-    <li>If reporting via email please make the subject line more useful than "<i>multis?</i>" Something like "<i>Multis: Username1 and Username2?</i>" is more helpful for the moderators</li>
-    </ul></li>
-</ul>
-<p>We will try to reply to you quickly, but be patient: investigations can take quite some time. If a week or two after we still haven't got back to you then please feel free to follow it up.</p>
-
-
-
-<div class="hr"></div>
-
-<p>Thanks for reading,<br />
-- The Mod/Admin Team</p>
-
+   <p class = "rules">Thanks for reading,<br />
+      - The Mod/Admin Team
+   </p>
 </div>
+
+<script type="text/javascript">
+   var coll = document.getElementsByClassName("rules_title");
+   var searchCounter;
+   
+   for (searchCounter = 0; searchCounter < coll.length; searchCounter++) {
+     coll[searchCounter].addEventListener("click", function() {
+       this.classList.toggle("active");
+       var content = this.nextElementSibling;
+   		if (content.style.display === "block") { content.style.display = "none"; } 
+   		else { content.style.display = "block"; }
+     });
+   }
+</script>

--- a/locales/English/tournaments.php
+++ b/locales/English/tournaments.php
@@ -1,0 +1,39 @@
+<div class="helpPage">
+   <a name="Tournaments"></a>
+   <h3 class = "rules"> Tournaments and Feature games:</h3>
+   <div class = "rules_content_show">
+      <p>There are two types of special games on the site. If you're interested in starting or running either type please email the mod team (see the contact details below) and explain your idea to the moderator team. </p>
+      <h4>1. Feature Games</h4>
+      <p>
+         These are special rule games like Chainsaw diplomacy, Pacifist diplomacy, or School of War games. They may involve violating some site rules so a predefined set of rules must be agreed upon by every participant. 
+      </p>
+      <ul>
+         <li>No more than 14 players (exception being a world game)</li>
+         <li>May require shuffling players by the moderator team</li>
+         <li>Must email <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
+            <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> for quick approval, this email should include participants, pause agreements (if any), end game requirements (if any), and alteration to press rules (if any).
+         </li>
+      </ul>
+      <h4>2. Tournaments</h4>
+      <p>
+         These are larger series of games with unique scoring rules to determine a winner. These games will have a Tournament Director (TD), who will oversee all aspects of the tournament. This person will be responsible for making decisions relating to the scoring, pauses, and anything affecting game play. 
+      </p>
+      <ul>
+         <li>Potential TD's must request approval *before* advertising. The moderator team reserves the right to deny tournaments or tournament directors.</li>
+         <li>TD's must include a set of rules for potential participants to agree upon, that all participants must agree too. Mid-Tournament rule changes are discouraged and require new permission from the moderator team.</li>
+         <li>The moderator team will enforce site-wide rules in tournaments as they do other games.</li>
+         <li>Discussion related to your or other players' usernames, as well as other potentially identifying information is strictly forbidden in all anonymous tournament games.</li>
+         <li>All press and negotiations must take place within game chat in all anonymous tournament games.</li>
+         <li>Players within tournaments must accept that the TD moderates their own tournament decisions. Please choose which tournaments to join carefully.</li>
+         <li>TD's may not play in their own tournaments.</li>
+         <li>TD's may utilize WFO (Wait for Orders) mode to prevent NMR's in games.</li>
+         <li>TD's may request the list and position of players in their tournament even in anonymous games.</li>
+         <li>TD's may request the moderator team pm or email any player with questions or warnings regarding the tournament. </li>
+         <li>TD's may request a message be posted in every games public messaging, including anon games, to remind participants of tournament rules or for tournament scoring updates.</li>
+         <li>As with all mod/admin decisions if you disagree with a TD's decision you can appeal it directly to an admin or owner. See below for the mod/admin contact details.</li>
+      </ul>
+      <p>Please e-mail the mod/admin team at <a href="mailto:<?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?>" class="light">
+         <?php print (isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail); ?></a> if you want to start a tournament (see the contact details below), and you will be asked to fill out an application form that will help us set the tournament up.
+      </p>
+   </div>
+</div>

--- a/tournaments.php
+++ b/tournaments.php
@@ -1,0 +1,35 @@
+<?php
+/*
+    Copyright (C) 2004-2010 Kestas J. Kuliukas
+
+	This file is part of webDiplomacy.
+
+    webDiplomacy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    webDiplomacy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with webDiplomacy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @package Base
+ * @subpackage Static
+ */
+
+require_once('header.php');
+
+libHTML::starthtml();
+
+print libHTML::pageTitle(l_t('webDiplomacy Tournaments'),l_t('Information on Tournaments and Feature Game rules and setup.'));
+
+require_once(l_r('locales/English/tournaments.php'));
+
+print '</div>';
+libHTML::footer();


### PR DESCRIPTION
1. Updating Rules content and style
2. Making a contact us page which will be altered in the future to have a direct contact form to email mods from in site.
3. Making a tournament page with info on tournaments
4. adjust credits page to have relative links.