### PR TITLE
Adjust Query for Speed

### DIFF
--- a/index.php
+++ b/index.php
@@ -309,7 +309,7 @@ class libHome
                 if ($User->options->value['displayUpcomingLive'] == 'No') return ''; 
 
 		$tabl=$DB->sql_tabl("SELECT g.* FROM wD_Games g
-			WHERE (g.phase = 'Pre-game' OR (g.minimumBet is not null and g.gameOver = 'No')) AND g.phaseMinutes < 60 AND g.password IS NULL
+			WHERE (g.phase = 'Pre-game' OR (g.phase in ('Diplomacy','Retreats','Builds') and g.minimumBet is not null and g.gameOver = 'No')) AND g.phaseMinutes < 60 AND g.password IS NULL
 			ORDER BY g.processStatus ASC, g.processTime ASC LIMIT 3");
 		$buf = '';
 		$count=0;


### PR DESCRIPTION
The live game check query was taking .22 seconds to render due to the new or hitting finished games. Adding in phase checks on an indexed field to reduce that check set to rerender in 0.00 seconds.