### PR TITLE
Add Emergency Pauses

### DIFF
--- a/admin/adminActions.php
+++ b/admin/adminActions.php
@@ -100,6 +100,11 @@ class adminActions extends adminActionsForms
 				'description' => 'Resets a users password',
 				'params' => array('userID'=>'User ID'),
 			),
+			'updateEmergencyDate' => array(
+				'name' => 'Adjust Emergency Date',
+				'description' => 'Enter 0 to grant the user another emergency pause, enter 1 to stop this user from having emergency pauses.',
+				'params' => array('userID'=>'User ID','setting'=>'Setting'),
+			),
 			'setProcessTimeToPhase' => array(
 				'name' => 'Reset process time',
 				'description' => 'Set a game process time to now + the phase length, resetting the turn length',
@@ -1116,6 +1121,18 @@ class adminActions extends adminActionsForms
 		}
 
 		return l_t('This user was transferred %s %s.',$points,libHTML::points());
+	}
+	public function updateEmergencyDate(array $params)
+	{
+		global $DB;
+
+		$userID = (int)$params['userID'];
+		$setting = (int)$params['setting'];
+		$targetUser = new User($userID);
+		
+		if( $setting >= 0 ) { $targetUser->updateEmergencyPauseDate($setting); }
+		
+		return 'This users emergency pause date was set to '.$setting;
 	}
 	public function unbanUser(array $params)
 	{

--- a/contactUsDirect.php
+++ b/contactUsDirect.php
@@ -10,6 +10,7 @@ require_once(l_r('pager/pagergame.php'));
 require_once(l_r('objects/game.php'));
 require_once(l_r('gamepanel/game.php'));
 require_once(l_r('objects/mailer.php'));
+require_once(l_r('gamemaster/game.php'));
 
 global $Mailer;
 $Mailer = new Mailer();
@@ -30,6 +31,7 @@ $postedGameName = '';
 $postedGameIssue = '';
 $postedOtherIssue = '';
 $postedAdditionalInfo = '';
+$postedEmergencyIssue = '';
 
 $subject = '';
 $actualProblem = '';
@@ -45,7 +47,9 @@ class GameResultData
 	public $phaseMinutes;
 	public $anon; 						// yes/no 
 	public $pressType; 				//enum('Regular','PublicPressOnly','NoPress','RulebookPress')
-	public $directorUserID;
+    public $directorUserID;
+    public $processTime;
+    public $phase;
 }
 
 // Game Search Variables
@@ -59,6 +63,7 @@ if(isset($_POST['submit']))
     {
         if ($_POST['issueType'] == 'gameIssue') { $issueType='gameIssue'; }
         else if ($_POST['issueType'] == 'otherIssue') { $issueType='otherIssue'; }
+        else if ($_POST['issueType'] == 'emergencyIssue') { $issueType='emergencyIssue'; }
     }
     if ($issueType=='gameIssue')
     {
@@ -150,6 +155,29 @@ if(isset($_POST['submit']))
         }
     }
 
+    else if ($issueType =='emergencyIssue')
+    {
+        $subject = 'WebDip Generated Emergency Pause';
+        if(isset($_POST['emergencyIssue'])) 
+        {
+            if ($_POST['emergencyIssue'] == 'naturalDisaster') 
+            { 
+                $postedEmergencyIssue='naturalDisaster'; 
+                $actualProblem = 'user paused all games for a natural disaster impacting them';
+            }
+            else if ($_POST['emergencyIssue'] == 'medical') 
+            { 
+                $postedEmergencyIssue='medical'; 
+                $actualProblem = 'user paused all games for a medical emergency';
+            }
+            else if ($_POST['emergencyIssue'] == 'powerOutage') 
+            { 
+                $postedEmergencyIssue='powerOutage'; 
+                $actualProblem = 'user paused all games due to a power outage';
+            }
+        }
+    }
+
     // Use db escape to guard against special characters. 
     if(isset($_POST['additionalInfo']) && strlen($_POST['additionalInfo'])) 
     {
@@ -164,16 +192,19 @@ print libHTML::pageTitle(l_t('Contact Us'),l_t('Directly submit a support reques
 ?>
 
 <?php
-$sql = "SELECT g.id, g.name, g.pot, g.gameOver, g.processStatus, ( CASE WHEN g.password IS NULL THEN 'False' ELSE 'True' END ) AS password,
-				g.phaseMinutes, g.anon, g.pressType, g.directorUserID 
+$sql = "SELECT g.id, g.name, g.gameOver, g.processStatus, ( CASE WHEN g.password IS NULL THEN 'False' ELSE 'True' END ) AS password,
+				g.phaseMinutes, g.anon, g.pressType, g.directorUserID, g.processTime, g.phase
                 FROM wD_Games g 
                 inner join wD_Members m on m.gameID = g.id
-                WHERE g.gameOver = 'No' and m.status <> 'Defeated' and m.userID = ". $User->id;
+                WHERE g.gameOver = 'No' and g.phase <> 'Pre-Game' and m.status = 'Playing' and m.userID = ". $User->id;
 
 $tablChecked = $DB->sql_tabl($sql);
 $allGames = '';
+$allRunningGames = '';
 
-while (list($gameID, $gameName, $gameOver, $processStatus, $password, $phaseMinutes, $anon, $pressType, $directorUserID) = $DB->tabl_row($tablChecked))
+$numberOfGames = 0;
+
+while (list($gameID, $gameName, $gameOver, $processStatus, $password, $phaseMinutes, $anon, $pressType, $directorUserID, $processTime, $phase) = $DB->tabl_row($tablChecked))
 {   
     $myGame = new GameResultData();
     $myGame->gameID = $gameID;
@@ -184,9 +215,19 @@ while (list($gameID, $gameName, $gameOver, $processStatus, $password, $phaseMinu
     $myGame->anon = $anon;
     $myGame->pressType = $pressType;
     $myGame->directorUserID = $directorUserID;
+    $myGame->processStatus = $processStatus;
+    $myGame->processTime = $processTime;
+    $myGame->phase = $phase;
     array_push($GamesData,$myGame);
 
     $allGames = $allGames.'https://www.webdiplomacy.net/board.php?gameID='.$gameID.'<br>';
+
+    if($processStatus != 'Paused' )
+    {
+        $allRunningGames = $allRunningGames.'https://www.webdiplomacy.net/board.php?gameID='.$gameID.'<br>';
+        $numberOfGames = $numberOfGames+1;
+    }
+    
     if ($gamesValid == false && $games == $gameID)
     {     
         $gamesValid = true;
@@ -212,29 +253,104 @@ if ($submitted == true)
     }
 
     $worked = true;
-    try
-	{
-        $Mailer->Send(array($email=>$email), $subject.' '.$User->username,
-        "
-        This request is from <a href='https://www.webdiplomacy.net/profile.php?userID=".$User->id."' class = 'contactUs'>".$User->username. "</a>
-        , and their registered email is: ".$User->email."<br><br>
+    $pausedGames = '';
 
-        <strong>The user called out ".$userPickedGame. ".</strong><br><br>
-        The ".$actualProblem." and their games are: <br><br>".$allGames. "
-        
-        <br><br>
-        <strong>Additional Information:</strong> <br><br>
-        ".$postedAdditionalInfo."</br></br>
+    if ($issueType=='emergencyIssue')
+    {
+        if ($User->qualifiesForEmergency())
+        {
+            foreach ($GamesData as $values)
+            {      
+                // This is a reduced version of the toggle Pause function, altered so that it can only impact non-paused games. 
+                if ($values->processStatus != 'Paused')
+                {
+                    if($values->phase != 'Pre-game' && $values->phase != 'Finished' && $values->processStatus == 'Not-processing')
+                    {
+                        // Use processTime to find pauseTimeRemaining
+                        $pauseTimeRemaining = $values->processTime - time();
+                        $processTime=false;
+                        
+                        $DB->sql_put(
+                            "UPDATE wD_Games 
+                            SET processStatus = 'Paused',
+                                pauseTimeRemaining = ".(false===$pauseTimeRemaining ? "NULL" : $pauseTimeRemaining).",
+                                processTime = ".(false===$processTime ? "NULL" : $processTime)."
+                            WHERE id = ".$values->gameID);
 
-        ");
+                        // Any votes to toggle the pause are now void
+                        $DB->sql_put("UPDATE wD_Members SET votes = REPLACE(votes,'Pause','') WHERE gameID = ".$values->gameID);
+                    }
+                }
+            }
+
+            // Update the users emergency pause time to now.
+            $User->updateEmergencyPauseDate(time());
+
+            // Add a record to the admin log just in case the email fails.
+            $DB->sql_put("
+            INSERT INTO wD_AdminLog ( name, userID, time, details, params )
+            VALUES ( 'Emergency Pause', ".$User->id.", ".time().", 'The following games were paused due to a player emergency ', '".$allRunningGames."' )");
+
+            try
+            {
+                $Mailer->Send(array($email=>$email), $subject.' '.$User->username,
+                "
+                This request is from <a href='https://www.webdiplomacy.net/profile.php?userID=".$User->id."' class = 'contactUs'>".$User->username."</a>, 
+                and their registered email is: ".$User->email."<br><br>
+
+                <strong>An emergency pause was used because of ".$actualProblem."</strong>
+                
+                <br><br>
+                All the games impacted will need a moderator to post in the global chat explaining why the game was paused. Simply say 'A user in this game
+                needed an emergency pause', do <strong>not</strong> give the reason.
+                The games that were paused as a result of this are: <br><br>".$allRunningGames. "
+                
+                <br><br>
+                Please note that any games they are in that were already paused will NOT show up in the above list. Please check all this users games to make sure none are 
+                about to be unpaused and then follow up with the user to see how long they need this pause for and determine if the reason was acceptable.
+
+                <br><br>
+                <strong>Additional Information:</strong> <br><br>
+                ".$postedAdditionalInfo."</br></br>
+
+                ");
+            }
+            catch(Exception $e)
+            {
+                print '<div class="contactUs"> Sorry, but there was a problem sending this message, contact the moderator team directly at '.Config::$modEMail;
+                print '<p class="contactUs">'.$e->getMessage().'</p>';
+                print '</div>';
+                $worked = false;
+            }
+        }
     }
-    catch(Exception $e)
-	{
-		print '<div class="contactUs"> Sorry, but there was a problem sending this message, if this is an emergency contact the moderator team directly at '.Config::$modEMail;
-		print '<p class="contactUs">'.$e->getMessage().'</p>';
-		print '</div>';
-        $worked = false;
-	}
+
+    else
+    {
+        try
+        {
+            $Mailer->Send(array($email=>$email), $subject.' '.$User->username,
+            "
+            This request is from <a href='https://www.webdiplomacy.net/profile.php?userID=".$User->id."' class = 'contactUs'>".$User->username."</a>, 
+            and their registered email is: ".$User->email."<br><br>
+
+            <strong>The user called out ".$userPickedGame. ".</strong><br><br>
+            The ".$actualProblem." and their games are: <br><br>".$allGames. "
+            
+            <br><br>
+            <strong>Additional Information:</strong> <br><br>
+            ".$postedAdditionalInfo."</br></br>
+
+            ");
+        }
+        catch(Exception $e)
+        {
+            print '<div class="contactUs"> Sorry, but there was a problem sending this message, if this is an emergency contact the moderator team directly at '.Config::$modEMail;
+            print '<p class="contactUs">'.$e->getMessage().'</p>';
+            print '</div>';
+            $worked = false;
+        }
+    }
 
     if ($worked == true)
     {
@@ -279,7 +395,16 @@ else
     print '<form action="#" method="post">';
     print   '<p><strong>What do you need to contact us about?</strong></p>
             Issue with game(s) <input type="radio" value="gameIssue" onclick="javascript:gameIssueCheck();" name="issueType" id="gameIssue" required> 
-            </br>Other issue <input type="radio" value="otherIssue" onclick="javascript:gameIssueCheck();" name="issueType" id="otherIssue"><br>';
+            </br>Other issue <input type="radio" value="otherIssue" onclick="javascript:gameIssueCheck();" name="issueType" id="otherIssue">';
+    if ($numberOfGames > 0 && $User->qualifiesForEmergency() )
+    {
+        print   '</br>Personal Emergency (Automatic Pause)
+                <input type="radio" value="emergencyIssue" onclick="javascript:gameIssueCheck();" name="issueType" id="emergencyIssue"><br>';
+    }
+    else
+    {
+        print   '<input type="radio" value="emergencyIssue" style="display:none" name="issueType" id="emergencyIssue">';
+    }
             
     print '<div id="ifGames" style="display:none">
             <p>Which game(s): </br>
@@ -287,8 +412,9 @@ else
                 <option selected="selected" value="0">None</option>
                 <option value="1">All</option>';
 
+    
     foreach ($GamesData as $values)
-    {      
+    {   
         print '<option value="'.$values->gameID.'">'.$values->gameName.'</option>';	
     }
 
@@ -320,6 +446,31 @@ else
                 <option value="other">Other</option>
             </select></p>';
     print '</div>';
+
+    print '<div id="ifEmergency" style="display:none">';
+    print '<p> <font color="red">This is for personal emergencies only and will instantly pause all of your running games that you are not defeated in. The
+    moderator team will give you 7 days to let us know when you expect to be back. If we do not hear back in 7 days we will look for a replacement. <br><br>
+    Abuse will be punished with a 50% point dock at minimum. <strong>Vacations do not count as a personal emergency.</strong></font></br></br>
+    Using your emergency pause will instantly pause the following games: ';
+    
+    $counter = 1;
+    foreach ($GamesData as $values)
+    {      
+        if ($values->processStatus != 'Paused')
+        {
+            print $values->gameName;	
+            if ($counter < $numberOfGames) print ', ';
+            $counter++;
+        }
+    }
+    print'</br></br>To prevent abuse we need to know the reason for the emergency pause. We will follow up with this request later at '.$User->email.' to find 
+    out how long you need your games to be paused.</br></br>
+            <select class="contactUs" name="emergencyIssue">
+                <option value="medical" selected="selected">Illness or injury to yourself/family</option>
+                <option value="naturalDisaster">Natural Disaster</option>
+                <option value="powerOutage">Power Outage</option>
+            </select></p>';
+    print '</div>';
     
     print ' <p>Please give us any additional details
             <textarea name="additionalInfo" class = "contactUs"  rows="5"></textarea></p>';
@@ -328,6 +479,7 @@ else
 }
 print '</div>';
 print '</div>';
+
 ?>
 
 <script type="text/javascript">
@@ -337,11 +489,19 @@ function gameIssueCheck()
     {
         document.getElementById('ifGames').style.display = 'block';
         document.getElementById('ifOther').style.display = 'none';
+        document.getElementById('ifEmergency').style.display = 'none';
+    }
+    else if (document.getElementById('emergencyIssue').checked)
+    {
+        document.getElementById('ifGames').style.display = 'none';
+        document.getElementById('ifOther').style.display = 'none';
+        document.getElementById('ifEmergency').style.display = 'block';
     }
     else 
     {
         document.getElementById('ifGames').style.display = 'none';
         document.getElementById('ifOther').style.display = 'block';
+        document.getElementById('ifEmergency').style.display = 'none';
     }
 }
 </script>

--- a/global/definitions.php
+++ b/global/definitions.php
@@ -24,7 +24,7 @@
 
 defined('IN_CODE') or die('This script can not be run by itself.');
 
-define("VERSION", 147);
+define("VERSION", 148);
 
 // Some integer values which are named for clarity.
 

--- a/install/1.47-1.48/readme.txt
+++ b/install/1.47-1.48/readme.txt
@@ -1,0 +1,6 @@
+Changelog
+---------
+* Adding a column to wD_Users to hold the last time they used an emergency pause 
+
+Updating
+--------

--- a/install/1.47-1.48/update.sql
+++ b/install/1.47-1.48/update.sql
@@ -1,0 +1,3 @@
+UPDATE `wD_Misc` SET `value` = '148' WHERE `name` = 'Version';
+
+ALTER TABLE `wD_Users` ADD `emergencyPauseDate` int(10) unsigned Default 0;

--- a/profile.php
+++ b/profile.php
@@ -651,6 +651,19 @@ if( $User->type['Moderator'] )
 	{
 		print '<p>Investigated: Never</p>';
 	}
+
+	if($UserProfile->qualifiesForEmergency() )
+	{
+		print '<p class="profileCommentURL">User qualifies for emergency pause</p>';
+	} 
+	else if ($UserProfile->emergencyPauseDate == 1)
+	{
+		print '<p class="profileCommentURL">User is mod banned from emergency pause</p>';
+	}
+	else
+	{
+		print '<p class="profileCommentURL">User does not qualify for emergency pause</p>';
+	}
 }
 
 list($serverHasPHPBB) = $DB->sql_row("SELECT count(1) FROM information_schema.tables WHERE table_name = 'phpbb_users'");
@@ -671,15 +684,12 @@ print '<p><ul class="formlist">';
 
 if ( $UserProfile->type['Moderator'] ||  $UserProfile->type['ForumModerator'] || $UserProfile->type['Admin'] )
 {
-	if ($UserProfile->id !=15658)
-	{
-		print '<li><strong>'.l_t('Mod/Admin team').'</strong></li>';
-		print '<li>'.l_t('The best way to get moderator assistance is to contact a moderator at 
-		<a href="mailto:'.(isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail).'">'
-		.(isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail).'</a>. Please do not pm 
-		moderators directly as moderators are not required to regularly check their messages').'</li>';
-		print '<li>&nbsp;</li>';
-	}
+	print '<li><strong>'.l_t('Mod/Admin team').'</strong></li>';
+	print '<li>'.l_t('The best way to get moderator assistance is to contact a moderator at 
+	<a href="mailto:'.(isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail).'">'
+	.(isset(Config::$modEMail) ? Config::$modEMail : Config::$adminEMail).'</a>. Please do not pm 
+	moderators directly as moderators are not required to regularly check their messages').'</li>';
+	print '<li>&nbsp;</li>';
 }
 
 if ( $UserProfile->online || time() - (24*60*60) < $UserProfile->timeLastSessionEnded)


### PR DESCRIPTION
Allow 1 automatic pause of all games for players who have completed at least 10 games and have not used an automatic pause in the last 6 months. Adds a mod tool to reset the time if a player presents a valid excuse or the option to ban members from using this tool at all. Mods can see on the profile page if a member qualifies for an automatic pause or not. This tool pauses the games and then emails the moderator team so they can follow up and post an explaination in the game chat.