### PR TITLE
Config banner

### DIFF
--- a/admin/adminActionsForms.php
+++ b/admin/adminActionsForms.php
@@ -66,7 +66,7 @@ class adminActionsForms
 			print '<input type="hidden" name="globalUserID" value="'.intval($_REQUEST['globalUserID']).'" />';
 		if ( isset($_REQUEST['globalPostID']) )
 			print '<input type="hidden" name="globalPostID" value="'.intval($_REQUEST['globalPostID']).'" />';
-		
+
 		if ($description)
 			print '<li class="modToolsformlistdesc" style="margin-bottom:10px">'.l_t($description).'</li>';
 
@@ -84,10 +84,20 @@ class adminActionsForms
 			else
 				$defaultValue = '';
 
-			print '<li class="modToolsformlistfield">
-					<label for="'.$paramCode.'">'.l_t($paramName).'</label>:
-					<input class = "modTools" type="text" name="'.$paramCode.'" value="'.$defaultValue.'" length="50" />
-					</li>';
+			if ($paramCode == 'message')
+			{
+				print '<li class="modToolsformlistfield">
+						<label for="'.$paramCode.'">'.l_t($paramName).'</label>:
+						<textarea rows = "5" cols = "50" class="modTools" name="'.$paramCode.'"></textarea>
+						</li>';
+			}
+			else
+			{
+				print '<li class="modToolsformlistfield">
+						<label for="'.$paramCode.'">'.l_t($paramName).'</label>:
+						<input class = "modTools" type="text" name="'.$paramCode.'" value="'.$defaultValue.'"/>
+						</li>';
+			}
 		}
 
 		print '<li class="modToolsformlistfield">
@@ -127,19 +137,19 @@ class adminActionsForms
 		$DB->sql_put("INSERT INTO wD_AdminLog ( name, userID, time, details, params )
 					VALUES ( '".$name."', ".$User->id.", ".time().", '".$details."', '".$paramValues."' )");
 	}
-	
+
 	/**
 	 * Defines the PHP script which the forms will target; will either be board.php or admincp.php
 	 * @var string
 	 */
 	public static $target;
-	
+
 	/**
 	 * A reference to the static array of actions
 	 * @var array
 	 */
 	public $actionsList;
-	
+
 	/**
 	 * For the given task display the form, and run the task if data entered from the corresponding form
 	 *
@@ -329,11 +339,11 @@ require_once(l_r('lib/gamemessage.php'));
 if( defined("INBOARD") )
 {
 	// We're running in Director mode from within board.php
-	
+
 	$adminActions = new adminActionsTD();
 	adminActionsForms::$target = "board.php?gameID=".$Game->id;
 	$adminActions->actionsList = adminActionsTD::$actions;
-	
+
 	print '<h3>'.l_t('Director action forms').'</h3>';
 	// For each task display the form, and run the task if data entered from the corresponding form
 	print '<ul class="formlist">';
@@ -347,37 +357,37 @@ else
 {
 	print '<h2 class="modToolsHeadings">'.l_t('Emergency Actions').'</h2>';
 	adminActionsLayout::printActionShortcuts();
-	
+
 	if ( $User->type['Admin'] )
 		$adminActions = new adminActionsRestricted();
 	elseif ( $User->type['ForumModerator'] )
 		$adminActions = new adminActionsForum();
 	else
 		$adminActions = new adminActions();
-	
+
 	adminActionsForms::$target = "admincp.php";
 	$adminActions->actionsList = adminActions::$actions;
-	
+
 	// Create a bullet-point set of anchor shortcuts to each task
-	
+
 	$actionCodesByType = adminActionsLayout::actionCodesByType();
-	
+
 	print '<h2 class="modToolsHeadings">'.l_t('Menu').'</h2>';
 	foreach($actionCodesByType as $type=>$actionCodes)
 	{
 		print '<a name="'.strtolower($type).'Actions"></a><h3 class = "modToolsHeadings">'.l_t($type.' actions').'</h3>';
 		adminActionsLayout::printActionLinks($actionCodes);
 	}
-	
+
 	print '<div class="hr"></div>';
-	
+
 	print '<h2 class="modToolsHeadings">'.l_t('All Actions').'</h2>';
 	// For each task display the form, and run the task if data entered from the corresponding form
 	print '<ul class="formlist">';
 	foreach($actionCodesByType as $type=>$actionCodes)
 	{
 		print '<h3 class="modToolsHeadings">'.l_t($type.' actions').'</h3>';
-	
+
 		foreach($actionCodes as $actionCode)
 			$adminActions->process($actionCode);
 	}

--- a/admin/adminActionsRestricted.php
+++ b/admin/adminActionsRestricted.php
@@ -21,8 +21,8 @@
 defined('IN_CODE') or die('This script can not be run by itself.');
 
 /**
- * This class will enable adminActions and adminActionsForum moderator 
- * tasks to be performed, but also allow tasks which only admins should 
+ * This class will enable adminActions and adminActionsForum moderator
+ * tasks to be performed, but also allow tasks which only admins should
  * be able to perform.
  * This will be included anyway, but the class will only be initialized if
  * the user is an admin.
@@ -57,7 +57,7 @@ class adminActionsRestricted extends adminActionsForum
 			'clearAccessLogs' => array(
 				'name' => 'Clear access logs',
 				'description' => 'Clears access log table of logs older than 30 days.</br>
-					<em>WARNING:</em> Doing this will make catching cheaters difficult or impossible. 
+					<em>WARNING:</em> Doing this will make catching cheaters difficult or impossible.
 					If possible, please take a backup if possible before clearing this table.',
 				'params' => array(),
 			),
@@ -65,7 +65,7 @@ class adminActionsRestricted extends adminActionsForum
 				'name' => 'Clear admin logs',
 				'description' => 'Clears admin log table.</br>
 					<em>WARNING:</em> Doing this removes the record of Moderator actions from the site.
-					This makes referencing past actions impossible, and damages moderator ability to function. 
+					This makes referencing past actions impossible, and damages moderator ability to function.
 					If possible, please take a backup if possible before clearing this table.',
 				'params' => array(),
 			),
@@ -127,15 +127,29 @@ class adminActionsRestricted extends adminActionsForum
 			),
 			'notice' => array(
 				'name' => 'Toggle site-wide notice',
-				'description' => 'Toggle the notice which is displayed in a noticebar across the whole site. The
-					notice itself can be set in config.php',
+				'description' => 'Toggle the notice which is displayed in a noticebar across the whole site.',
 				'params' => array(),
+			),
+			'noticeMessage' => array(
+				'name' => 'Change site-wide notice message',
+				'description' => 'Sets the notice which is displayed in a noticebar across the whole site.',
+				'params' => array('message'=>'Message'),
 			),
 			'maintenance' => array(
 				'name' => 'Toggle maintenance',
 				'description' => 'Toggle maintenance mode, which makes the server inaccessible except to admins
 					so changes can be made.',
 				'params' => array(),
+			),
+			'maintenanceMessage' => array(
+				'name' => 'Change maintenance message',
+				'description' => 'Change the message that is displayed while the site is undergoing maintenance.',
+				'params' => array('message'=>'Message'),
+			),
+			'panicMessage' => array(
+				'name' => 'Change panic message',
+				'description' => 'Change the message that is displayed while the site is in panic mode.',
+				'params' => array('message'=>'Message'),
 			),
 			'globalAddTime' => array(
 				'name' => 'Add time to all games',
@@ -170,13 +184,13 @@ class adminActionsRestricted extends adminActionsForum
 			'recreateUnitDestroyIndex' => array(
 				'name' => 'Recreate the destroy unit indexes',
 				'description' => 'Refreshes the unit destroy indexes for a certain map ID. This will generally only
-					be run if there has been a bug found in the unit destroy index generation code which requires 
+					be run if there has been a bug found in the unit destroy index generation code which requires
 					the indexes to be recreated.<br />
 					Note that this uses the generic installation code, so if there are any variant-specific modifications
 					running this may give unpredictable results. Please confirm with the variant maintainer before
 					using this admin action.',
 				'params' => array('mapID'=>'Map ID'),
-			),		
+			),
 			'recalculateRR' => array(
 				'name' => 'Recalculate reliability ratings',
 				'description' => 'Updates the reliability ratings for all users.',
@@ -206,7 +220,7 @@ class adminActionsRestricted extends adminActionsForum
 	public function backupGame(array $params)
 	{
 		global $DB;
-		
+
 		require_once(l_r('objects/game.php'));
 
 		$gameID = (int)$params['gameID'];
@@ -220,7 +234,7 @@ class adminActionsRestricted extends adminActionsForum
 	public function restoreGameConfirm(array $params)
 	{
 		global $DB;
-		
+
 		require_once(l_r('objects/game.php'));
 		$Variant=libVariant::loadFromGameID($params['gameID']);
 		$Game = $Variant->Game($params['gameID']);
@@ -230,7 +244,7 @@ class adminActionsRestricted extends adminActionsForum
 	public function restoreGame(array $params)
 	{
 		global $DB;
-		
+
 		require_once(l_r('gamemaster/game.php'));
 
 		$gameID = (int)$params['gameID'];
@@ -248,7 +262,7 @@ class adminActionsRestricted extends adminActionsForum
 	public function wipeBackups(array $params)
 	{
 		global $DB;
-		
+
 		require_once(l_r('gamemaster/game.php'));
 
 		processGame::wipeBackups();
@@ -319,6 +333,15 @@ class adminActionsRestricted extends adminActionsForum
 		return l_t('Maintenance mode '.($Misc->Maintenance?'turned on':'turned off'));
 	}
 
+	public function maintenanceMessage(array $params)
+	{
+		global $DB;
+		$message = $params['message'];
+		$message = $DB->escape($message, $htmlAllowed=true);
+		$DB->sql_put("UPDATE wD_Config SET message='".$message."' WHERE name = 'Maintenance'");
+		return l_t('The maintenance message has been updated.');
+	}
+
 	public function notice(array $params)
 	{
 		global $Misc;
@@ -327,6 +350,24 @@ class adminActionsRestricted extends adminActionsForum
 		$Misc->write();
 
 		return l_t('Site-wide notice '.($Misc->Notice?'turned on':'turned off'));
+	}
+
+	public function noticeMessage(array $params)
+	{
+		global $DB;
+		$message = $params['message'];
+		$message = $DB->escape($message, $htmlAllowed=true);
+		$DB->sql_put("UPDATE wD_Config SET message='".$message."' WHERE name = 'Notice'");
+		return l_t('The site-wide notice message has been updated.');
+	}
+
+	public function panicMessage(array $params)
+	{
+		global $DB;
+		$message = $params['message'];
+		$message = $DB->escape($message);
+		$DB->sql_put("UPDATE wD_Config SET message='".$message."' WHERE name = 'Panic'");
+		return l_t('The panic message has been updated.');
 	}
 
 	public function clearErrorLogs(array $params)
@@ -534,7 +575,7 @@ class adminActionsRestricted extends adminActionsForum
 		 * - Remove the invalid maps in the mapstore
 		 */
 		$DB->sql_put("BEGIN");
-		
+
 		require_once(l_r('gamemaster/game.php'));
 		$Variant=libVariant::loadFromGameID($gameID);
 		$Game = $Variant->processGame($gameID);
@@ -611,32 +652,32 @@ class adminActionsRestricted extends adminActionsForum
 		return l_t('This game was moved from %s, %s back to Diplomacy, %s, and is ready to be reprocessed.',
 			$oldPhase,$Game->datetxt($oldTurn),$Game->datetxt($lastTurn));
 	}
-	
+
 	public function recreateUnitDestroyIndex(array $params)
 	{
 		global $DB;
-		
+
 		$mapID = (int)$params['mapID'];
-		
+
 		require_once("variants/install.php");
-		
+
 		InstallTerritory::loadExistingTerritories($mapID);
-		
+
 		// Generate the SQL before wiping & reinserting it
 		$unitDestroyIndexRecreateSQL = InstallTerritory::unitDestroyIndexSQL($mapID);
-		
+
 		$DB->sql_put("BEGIN");
-		
+
 		list($entriesBefore) = $DB->sql_row("SELECT COUNT(*) FROM wD_UnitDestroyIndex WHERE mapID = ".$mapID);
-		
+
  		$DB->sql_put("DELETE FROM wD_UnitDestroyIndex WHERE mapID = ".$mapID);
- 		
+
  		$DB->sql_put($unitDestroyIndexRecreateSQL);
- 		
+
  		list($entriesAfter) = $DB->sql_row("SELECT COUNT(*) FROM wD_UnitDestroyIndex WHERE mapID = ".$mapID);
- 		
+
 		$DB->sql_put("COMMIT");
-		
+
 		return l_t('The unit destroy indexes were recreated for map ID #%s ; there were %s entries before and there are currently %s entries.', $mapID, $entriesBefore, $entriesAfter);
 	}
 	public function recalculateRR(array $params)

--- a/admin/adminStatusLists.php
+++ b/admin/adminStatusLists.php
@@ -26,7 +26,7 @@ defined('IN_CODE') or die('This script can not be run by itself.');
  * @package Admin
  */
 if( !isset($_REQUEST['full']) )
-	print '<p class = "modTools"> <a class="modTools" href="admincp.php?tab=Status Info&full=on">'.l_t('View all logs').'</a> 
+	print '<p class = "modTools"> <a class="modTools" href="admincp.php?tab=Status Info&full=on">'.l_t('View all logs').'</a>
 	</br> Error logs, banned users, and donator lists are limited to 50 items, use this link to see full result set.</p>';
 
 if( $User->type['Admin'] )
@@ -173,5 +173,13 @@ adminStatusList(l_t('Donors'),"SELECT CONCAT('<a href=\"profile.php?userID=',id,
 	FROM wD_Users WHERE type LIKE '%Donator%'".(isset($_REQUEST['full'])?'':"LIMIT 50"));
 adminStatusList(l_t('Banned users'),"SELECT CONCAT('<a href=\"profile.php?userID=',id,'\" class=\"light\">',username,'</a>')
 FROM wD_Users WHERE type LIKE '%Banned%'".(isset($_REQUEST['full'])?'':"LIMIT 50"));
+
+list($notice) = $DB->sql_row("SELECT message FROM wD_Config WHERE name = 'Notice'");
+list($panic) = $DB->sql_row("SELECT message FROM wD_Config WHERE name = 'Panic'");
+list($maintenance) = $DB->sql_row("SELECT message FROM wD_Config WHERE name = 'Maintenance'");
+print '<br/><br/>';
+print '<b>Site-Wide Notice: '.$notice.'</b><br/><br/>';
+print '<b>Panic Message: '.$panic.'</b><br/><br/>';
+print '<b>Maintenance Message: '.$maintenance.'</b><br/><br/>';
 
 ?>

--- a/global/definitions.php
+++ b/global/definitions.php
@@ -24,7 +24,7 @@
 
 defined('IN_CODE') or die('This script can not be run by itself.');
 
-define("VERSION", 148);
+define("VERSION", 149);
 
 // Some integer values which are named for clarity.
 

--- a/header.php
+++ b/header.php
@@ -57,32 +57,32 @@ if( strlen(Config::$serverMessages['ServerOffline']) )
 
 
 if( ini_get('request_order') !== false ) {
-	
+
 	// There is a request_order php.ini variable; this must be PHP 5.3.0+
-	
-	/* 
-	 * This variable determines whether $_COOKIE is included in $_REQUEST; 
+
+	/*
+	 * This variable determines whether $_COOKIE is included in $_REQUEST;
 	 * if request_order contains no 'c' then $_COOKIE is not included.
-	 * 
+	 *
 	 * $_COOKIE shouldn't be included in $_REQUEST, however since webDip
-	 * has historically relied on it being there this code is here 
-	 * temporarily, while the improper $_REQUEST references are found and 
+	 * has historically relied on it being there this code is here
+	 * temporarily, while the improper $_REQUEST references are found and
 	 * switched to $_COOKIE.
 	 */
 	if( substr_count(strtolower(ini_get('request_order')), 'c') == 0 ) {
 		/*
-		 * No 'c' in request_order, so no $_COOKIE variables in $_REQUEST; 
+		 * No 'c' in request_order, so no $_COOKIE variables in $_REQUEST;
 		 * $_COOKIE will need to be merged into $_REQUEST manually.
-		 * 
-		 * The default config used to be GPC ($_GET, $_POST, $_COOKIE), so 
-		 * to get the standard behaviour $_COOKIE overwrites variables 
+		 *
+		 * The default config used to be GPC ($_GET, $_POST, $_COOKIE), so
+		 * to get the standard behaviour $_COOKIE overwrites variables
 		 * already in $_REQUEST.
 		 */
-		
+
 		foreach($_COOKIE as $key=>$value)
 		{
-			$_REQUEST[$key] = $value; 
-			// array_merge could be used here, but creating a new array 
+			$_REQUEST[$key] = $value;
+			// array_merge could be used here, but creating a new array
 			// for use as a super-global can have weird results.
 		}
 	}
@@ -229,8 +229,9 @@ if( !defined('AJAX') )
 	}
 	elseif ( $Misc->Maintenance )
 	{
+		list($contents) = $DB->sql_row("SELECT message FROM wD_Config WHERE name = 'Maintenance'");
 		unset($DB); // This lets libHTML know there's a problem
-		libHTML::error(Config::$serverMessages['Maintenance']);
+		libHTML::error($contents);
 
 	}
 }

--- a/install/1.48-1.49/readme.txt
+++ b/install/1.48-1.49/readme.txt
@@ -1,0 +1,6 @@
+Changelog
+---------
+* Adding a table to hold messages originally found in the config file that can be changed through the admin cp.
+
+Updating
+--------

--- a/install/1.48-1.49/update.sql
+++ b/install/1.48-1.49/update.sql
@@ -1,0 +1,9 @@
+UPDATE `wD_Misc` SET `value` = '149' WHERE `name` = 'Version';
+
+CREATE TABLE `wD_Config` (
+  `name` enum('Notice','Panic','Maintenance','ServerOffline') NOT NULL,
+  `message` text NOT NULL,
+  PRIMARY KEY (`name`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+INSERT INTO `wD_Config` VALUES ('Notice','Default server-wide notice message.'),('Panic','Game processing has been paused and user registration has been disabled while a problem is resolved.'),('Maintenance',"Server is in maintenance mode; only admins can fully interact with the server."),('ServerOffline','');

--- a/install/FullInstall/fullInstall.sql
+++ b/install/FullInstall/fullInstall.sql
@@ -594,19 +594,19 @@ CREATE TABLE `wD_Silences` (
 ) ENGINE = InnoDB ;
 
 
-ALTER TABLE `wD_ForumMessages` 
+ALTER TABLE `wD_ForumMessages`
 ADD `silenceID` INT UNSIGNED NULL DEFAULT NULL ;
 
 
-ALTER TABLE `wD_Users` 
+ALTER TABLE `wD_Users`
 ADD `silenceID` INT UNSIGNED NULL DEFAULT NULL ;
 
 
-ALTER TABLE `wD_Users` 
-CHANGE `type` `type` SET( 
-	'Banned', 'Guest', 'System', 'User', 'Moderator', 
-	'Admin', 'Donator', 'DonatorBronze', 'DonatorSilver', 
-	'DonatorGold', 'DonatorPlatinum', 'ForumModerator' 
+ALTER TABLE `wD_Users`
+CHANGE `type` `type` SET(
+	'Banned', 'Guest', 'System', 'User', 'Moderator',
+	'Admin', 'Donator', 'DonatorBronze', 'DonatorSilver',
+	'DonatorGold', 'DonatorPlatinum', 'ForumModerator'
 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT 'User';
 
 
@@ -616,7 +616,7 @@ ALTER TABLE `wD_PointsTransactions` CHANGE `type` `type` ENUM( 'Supplement', 'Be
 
 ALTER TABLE `wD_ForumMessages`  ADD `likeCount` MEDIUMINT UNSIGNED NOT NULL DEFAULT '0';
 
-UPDATE wD_ForumMessages fm 
+UPDATE wD_ForumMessages fm
 INNER JOIN (
 	SELECT f.id, COUNT(*) as likeCount
 	FROM wD_ForumMessages f
@@ -627,7 +627,7 @@ SET fm.likeCount = l.likeCount;
 
 ALTER TABLE `wD_Members` CHANGE `newMessagesFrom` `newMessagesFrom` SET( '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63' ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '';
 ALTER TABLE `wD_Members` CHANGE `votes` `votes` set('Draw','Pause','Cancel') NOT NULL DEFAULT '';
-ALTER TABLE `wD_Members` CHANGE `countryID` `countryID` TINYINT( 3 ) UNSIGNED NOT NULL DEFAULT 0;  
+ALTER TABLE `wD_Members` CHANGE `countryID` `countryID` TINYINT( 3 ) UNSIGNED NOT NULL DEFAULT 0;
 
 UPDATE `wD_Misc` SET `value` = '132' WHERE `name` = 'Version';
 
@@ -653,7 +653,7 @@ CREATE TABLE `wD_VariantData` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 ALTER TABLE `wD_VariantData` ADD PRIMARY KEY ( `variantID` , `gameID`, `systemToken` , `typeID` , `userID` , `offset` ) ;
-   
+
 INSERT INTO wD_VariantData (variantID, systemToken, userID, offset, val_float )
 SELECT 1, 948379409, u.id, 1, ChanceEngland
 FROM wD_Users u
@@ -773,3 +773,13 @@ ALTER TABLE `wD_UserOptions` ADD `orderSort` enum('No Sort','Alphabetical','Conv
 UPDATE `wD_Misc` SET `value` = '148' WHERE `name` = 'Version';
 
 ALTER TABLE `wD_Users` ADD `emergencyPauseDate` int(10) unsigned Default 0;
+
+UPDATE 'wD_Misc' SET 'value' = '149' WHERE 'name' = 'Version';
+
+CREATE TABLE `wD_Config` (
+  `name` enum('Notice','Panic','Maintenance','ServerOffline') NOT NULL,
+  `message` text NOT NULL,
+  PRIMARY KEY (`name`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+INSERT INTO `wD_Config` VALUES ('Notice','Default server-wide notice message.'),('Panic','Game processing has been paused and user registration has been disabled while a problem is resolved.'),('Maintenance',"Server is in maintenance mode; only admins can fully interact with the server."),('ServerOffline','');

--- a/lib/html.php
+++ b/lib/html.php
@@ -29,7 +29,7 @@
 
 class libHTML
 {
-	public static function pageTitle($title, $description=false) 
+	public static function pageTitle($title, $description=false)
 	{
 		return '<div class="content-bare content-board-header content-title-header">
 <div class="pageTitle barAlt1">
@@ -315,7 +315,7 @@ class libHTML
 			return $output;
 	}
 
-	public static function threadLink($postID) 
+	public static function threadLink($postID)
 	{
 		global $DB;
 
@@ -493,7 +493,7 @@ class libHTML
 	 */
 	static private function globalNotices()
 	{
-		global $Misc, $User;
+		global $Misc, $User, $DB;
 		$notice=array();
 		if ( $Misc->Maintenance and isset($User) and $User->type['Admin'])
 		{
@@ -506,13 +506,16 @@ class libHTML
 				it until it is <a href="admincp.php?tab=Control Panel#maintenance">turned off</a>.';
 		}
 
-		if ( $Misc->Panic )
-		{
-			$notice[]=Config::$serverMessages['Panic'];
+		if ( $Misc->Panic ){
+			list($contents) = $DB->sql_row("SELECT message FROM wD_Config WHERE name = 'Panic'");
+			$notice[] = $contents;
 		}
 
-		if ( $Misc->Notice )
-			$notice[] = Config::$serverMessages['Notice'];
+		if ( $Misc->Notice ){
+			list($contents) = $DB->sql_row("SELECT message FROM wD_Config WHERE name = 'Notice'");
+			$notice[] = $contents;
+		}
+			#$notice[] = Config::$serverMessages['Notice'];
 
 		if ( ( time() - $Misc->LastProcessTime ) > Config::$downtimeTriggerMinutes*60 )
 			$notice[] = l_t("The last process time was over %s minutes ".
@@ -786,7 +789,7 @@ class libHTML
 					<div id="navSubMenu" class="clickable nav-tab">Search ▼
                         <div id="nav-drop">
                        		<a href="profile.php">Find User</a>
-							<a href="detailedSearch.php" title="advanced search of users and games">Search Games</a> 
+							<a href="detailedSearch.php" title="advanced search of users and games">Search Games</a>
 						</div>
 					</div>
 					<div id="navSubMenu" class="clickable nav-tab">Games ▼
@@ -831,7 +834,7 @@ class libHTML
 					$menu.=' <div id="navSubMenu" class = "clickable nav-tab">Mods ▼
                         <div id="nav-drop">
 							<a href="admincp.php">Admin CP</a>';
-						
+
 					if( isset(Config::$customForumURL) ) { $menu.='<a href="contrib/phpBB3/mcp.php">Forum CP</a>'; }
 						$menu.='
 							<a href="admincp.php?tab=Multi-accounts">Multi Finder</a>
@@ -910,7 +913,7 @@ class libHTML
 		close();
 	}
 
-	private static function footerDebugData() 
+	private static function footerDebugData()
 	{
 		global $Locale, $DB;
 
@@ -928,7 +931,7 @@ class libHTML
 		return $buf;
 	}
 
-	private static function footerStats() 
+	private static function footerStats()
 	{
 		global $DB, $Misc, $User;
 		require_once(l_r('global/definitions.php'));
@@ -1003,26 +1006,26 @@ class libHTML
 		return $buf;
 	}
 
-	static private function footerCopyright() 
+	static private function footerCopyright()
 	{
 		// Version, sourceforge and HTML compliance logos
 		return l_t('webDiplomacy version <strong>%s</strong>',number_format(VERSION/100,2)).'<br />
 			<a class="light" id="js-desktop-mode" style="cursor: pointer; color: #006699;" onclick="toggleDesktopMode()">Enable Desktop Mode</a> <br />
 			<a href="http://github.com/kestasjk/webDiplomacy" class="light">GitHub Project</a> |
 			<a href="http://github.com/kestasjk/webDiplomacy/issues" class="light">Bug Reports</a> | <a href="mailto:'.Config::$modEMail.'" class="light">Moderator Email</a> |
-			<a href="contactUsDirect.php" class="light">Contact Us Directly</a>';	
+			<a href="contactUsDirect.php" class="light">Contact Us Directly</a>';
 	}
 
 	public static $footerScript=array();
 	public static $footerIncludes=array();
 
-	public static function likeCount($likeCount) 
+	public static function likeCount($likeCount)
 	{
 		if($likeCount==0) return '';
 		return ' <span class="likeCount">(+'.$likeCount.')</span>';
 	}
 
-	static private function footerScripts() 
+	static private function footerScripts()
 	{
 		global $User, $Locale;
 


### PR DESCRIPTION
Fixes https://github.com/kestasjk/webDiplomacy/issues/63

Moves the site-wide notice, maintenance message, and panic message into a table, so that you do not need to mess with the config file to change the messages. Creates an admin tool for each message so that it can be changed via the admin control panel. Escapes all characters, and allows for html tags.