### PR TITLE
Fix ambiguous column error

### DIFF
--- a/gamesearch/searchItemSettings.php
+++ b/gamesearch/searchItemSettings.php
@@ -540,7 +540,7 @@ class searchExcusedNMRs extends searchItemCheckbox
 	{
 		$unchecked = $this->invertedChecks();
 		foreach($unchecked as $uncheck)
-			$WHERE[] = "NOT excusedMissedTurns='".$uncheck."'";
+			$WHERE[] = "NOT g.excusedMissedTurns='".$uncheck."'";
 	}
 }
 


### PR DESCRIPTION
excusedmissedturns is not ambiguous in specific cases of game search, adding alias to it.