### PR TITLE
Fix Footer for Mods

### DIFF
--- a/css/desktopOnly/global.css
+++ b/css/desktopOnly/global.css
@@ -11,6 +11,12 @@ html, body { min-height: 100%; }
 div.content-title-header {
     border-bottom:#bbb 1px solid !important;
 }
+.footerMax {
+	max-width: 800px;
+	text-align: center;
+	margin-left:auto; 
+  margin-right:auto;
+}
 div.pageTitle, .boardHeader .gameName {
     text-shadow: #999999 1px 1px 1px;
     font-size:22px !important;

--- a/css/global.css
+++ b/css/global.css
@@ -11,6 +11,12 @@ html, body { min-height: 100%; }
 div.content-title-header {
     border-bottom:#bbb 1px solid !important;
 }
+.footerMax {
+	max-width: 800px;
+	text-align: center;
+	margin-left:auto; 
+  margin-right:auto;
+}
 div.pageTitle, .boardHeader .gameName {
     text-shadow: #999999 1px 1px 1px;
     font-size:22px !important;

--- a/global/definitions.php
+++ b/global/definitions.php
@@ -47,7 +47,7 @@ define("CSSDIR", 'css');
 
 //Increment these versions whenever you update any js or css files for cachebusting
 define("JSVERSION",1.2);
-define("CSSVERSION",1.13);
+define("CSSVERSION",1.14);
 
 if( !defined('FACEBOOK') )
 	define('FACEBOOK',false);

--- a/objects/database.php
+++ b/objects/database.php
@@ -247,13 +247,13 @@ class Database {
 			'Slowest query'=>$this->slowestQuery
 		);
 
-		$buf .= '<table>';
+		$buf .= '<table class = "footerMax">';
 		foreach($stats as $name=>$val)
 			$buf .= '<tr><td>'.l_t($name).':</td><td>'.$val.' sec</td></tr>';
 		$buf .= '</table>';
 
-		$buf .= '<p><strong>'.l_t('Bad queries:').'</strong></p>';
-		$buf .= '<table>';
+		$buf .= '<p class = "footerMax"><strong>'.l_t('Bad queries:').'</strong></p>';
+		$buf .= '<table class = "footerMax">';
 		foreach($this->badQueries as $pair)
 			$buf .= '<tr><td style="width:5%">'.$pair[0].' sec</td><td>'.$pair[1].'</td></tr>';
 		$buf .= '</table>';


### PR DESCRIPTION
Currently the footer spans width 100 of the possible page and can blow up horribly when there are many "bad queries". Centering it, maxing it at 800px.