### PR TITLE
Show CD's After Game End

### DIFF
--- a/gamepanel/members.php
+++ b/gamepanel/members.php
@@ -98,28 +98,28 @@ class panelMembers extends Members
 		}
 
 		$extras ='';
-		if ($this->Game->hasModeratorPowers() && count($this->Game->civilDisorderInfo) != 0) 
+		// Show members CD users after a game is finished. 	
+		if (($this->Game->hasModeratorPowers() || $this->Game->phase == 'Finished') && count($this->Game->civilDisorderInfo) != 0) 
 		{ 
 				$extras = '<div class="bar titleBar modEyes">Civil Disorders</div><table><tbody>';
 				foreach ($this->Game->civilDisorderInfo as $userID => $CD) 
 				{
-						$cdUser = new User($userID);
-						$extras .= '<tr class="member memberAlternate1"><td class="memberLeftSide" style="white-space: nowrap;"><span><a href="profile.php?userID='.$userID .'">'.$cdUser->username.'</a>'.
-								' <span class="points">('.$cdUser->points.libHTML::points().User::typeIcon($cdUser->type).')'
-				.(defined('AdminUserSwitch') ? ' (<a href="board.php?gameID='.$this->Game->id.'&auid='.$cdUser->id.'" class="light">+</a>)':'') .
-								'</span></span></td><td class="memberRightSide">';
-						$extras .= '<span class="country' .$CD['countryID']. '">';
-						if( $CD['countryID']==0 )
-							 $extras .= 'Unassigned';
-						else
-								$extras .= $this->Game->Variant->countries[$CD['countryID']-1];
-						$extras .= '</span> (' .$this->Game->datetxt($CD['turn']). ') with ' .$CD['SCCount']. ' centres.';
+					$cdUser = new User($userID);
+					$extras .= '<tr class="member memberAlternate1"><td class="memberLeftSide" style="white-space: nowrap;"><span><a href="profile.php?userID='.$userID .'">'.$cdUser->username.'</a>'.
+							' <span class="points">('.$cdUser->points.libHTML::points().User::typeIcon($cdUser->type).')'
+					.(defined('AdminUserSwitch') ? ' (<a href="board.php?gameID='.$this->Game->id.'&auid='.$cdUser->id.'" class="light">+</a>)':'') .
+							'</span></span></td><td class="memberRightSide">';
+					$extras .= '<span class="country' .$CD['countryID']. '">';
+					if( $CD['countryID']==0 )
+							$extras .= 'Unassigned';
+					else
+							$extras .= $this->Game->Variant->countries[$CD['countryID']-1];
+					$extras .= '</span> (' .$this->Game->datetxt($CD['turn']). ') with ' .$CD['SCCount']. ' centres.';
 
-						$extras .= '</td></tr>';
+					$extras .= '</td></tr>';
 				}
 				$extras .= "</tbody></table>";
-               	
-		}				
+		}
 
 		return '<table>'.implode('',$membersList).'</table>'.$extras;
 	}


### PR DESCRIPTION
Allow all members to see the list of CD's during the course of the game after the game has finished.

Fix bug preventing mods from seeing CD users in their own finished games.

Fixes https://github.com/kestasjk/webDiplomacy/issues/226