### PR TITLE
Message Archive Paging

### DIFF
--- a/board/chatbox.php
+++ b/board/chatbox.php
@@ -367,7 +367,7 @@ class Chatbox
 					(
 						".$where."
 					)
-				order BY id ".($msgCountryID==-1?'ASC':'DESC').' '.($limit?"LIMIT ".$limit:""));
+				order BY id DESC ".($limit?"LIMIT ".$limit:""));
 
 		unset($where);
 
@@ -388,9 +388,9 @@ class Chatbox
 		$messagestxt = "";
 
 		$alternate = false;
-		for ( $i=count($messages); $i >= 1; --$i )
+		for ( $i = count($messages)-1; $i>=0; --$i )
 		{
-			$message = $messages[$i-1];
+			$message = $messages[$i];
 
 			$alternate = ! $alternate;
 

--- a/board/info/messages.php
+++ b/board/info/messages.php
@@ -26,23 +26,176 @@ defined('IN_CODE') or die('This script can not be run by itself.');
  * @package Board
  */
 
+$pagenum = 1;
+$resultsPerPage = 20;
+$maxPage = 0;
+$totalResults = 0;
+$msgFilter = -1;
 
-require_once('pager/pagerarchive.php');
+if ( isset($_REQUEST['pagenum'])) { $pagenum=(int)$_REQUEST['pagenum']; }
+if ( isset($_REQUEST['msgFilter'])) { $msgFilter=(int)$_REQUEST['msgFilter']; }
 
-list($itemsTotal) = $DB->sql_row("SELECT COUNT(*) FROM wD_GameMessages WHERE gameID = ".$Game->id." AND ".
-	"(toCountryID = 0".(isset($Member)?" OR fromCountryID = ".$Member->countryID." OR toCountryID = ".$Member->countryID:'').")");
-$pager = new PagerArchive($itemsTotal, $Game->id, 'Messages');
+$SQLCounter = "SELECT COUNT(*) FROM wD_GameMessages WHERE gameID = ".$Game->id." AND ";
 
-print $pager->html();
+if( !isset($Member) ) { $msgFilter = 0; }
+
+if ($msgFilter == -1)
+{
+	$SQLCounter .= "(toCountryID = 0".(isset($Member)?" OR fromCountryID = ".$Member->countryID." OR toCountryID = ".$Member->countryID:'').")";
+}
+elseif ($msgFilter == 0)
+{
+	$SQLCounter .= "toCountryID = 0";
+}
+else
+{
+	$SQLCounter .= "( toCountryID = ".$Member->countryID." AND fromCountryID = ".$msgFilter." ) OR ( fromCountryID = ".$Member->countryID." AND toCountryID = ".$msgFilter." )";
+}
 
 
+list($totalResults) = $DB->sql_row($SQLCounter);
+
+$maxPage = ceil($totalResults / $resultsPerPage);
+$remainder = ($maxPage * $resultsPerPage) - $totalResults;
+
+if ($pagenum == $maxPage)
+{
+	$SQLLimit = ($resultsPerPage * ($maxPage - $pagenum)) . "," . ($resultsPerPage - $remainder) .";";
+}
+else
+{
+	$SQLLimit = ($resultsPerPage * ($maxPage - $pagenum) - $remainder) . "," . $resultsPerPage .";";
+}
+
+print "<a name='results'></a>";
 print '<h4>'.l_t('Chat archive').'</h4>';
 
 print '<div class="variant'.$Game->Variant->name.'">';
 
-$CB = $Game->Variant->Chatbox();
-print '<table class="archive-messages-table">'.$CB->getMessages( -1, $pager->SQLLimit()).'</table>';
+if ($totalResults == 0)
+{
+	if ($msgFilter == -1)
+	{
+		print '<br/><strong>There are no messages for this game</strong>';
+	}
+	else
+	{
+		print '<br/><strong>There are no results for this country.</strong>';
+		printPageBar($pagenum, $maxPage, $msgFilter, $sortBar = True);
+		print '<br/> <br/>';
+	}
+}
+else
+{
+	printPageBar($pagenum, $maxPage, $msgFilter, $sortBar = True);
+	print '<br/> <br/>';
+
+	$CB = $Game->Variant->Chatbox();
+	print '<table class="archive-messages-table">'.$CB->getMessages( $msgFilter, $SQLLimit).'</table>';
+
+	print '</br>';
+	printPageBar($pagenum, $maxPage, $msgFilter);
+}
 
 print '</div>';
+
+function printPageBar($pagenum, $maxPage, $msgFilter, $sortBar = False)
+{
+	global $Game, $Member;
+	if ($pagenum > 3)
+	{
+		printPageButton(1,False);
+	}
+	if ($pagenum > 4)
+	{
+		print "...";
+	}
+	if ($pagenum > 2)
+	{
+		printPageButton($pagenum-2, False);
+	}
+	if ($pagenum > 1)
+	{
+		printPageButton($pagenum-1, False);
+	}
+	if ($maxPage > 1)
+	{
+		printPageButton($pagenum, True);
+	}
+	if ($pagenum < $maxPage)
+	{
+		printPageButton($pagenum+1, False);
+	}
+	if ($pagenum < $maxPage-1)
+	{
+		printPageButton($pagenum+2, False);
+	}
+	if ($pagenum < $maxPage-3)
+	{
+		print "...";
+	}
+	if ($pagenum < $maxPage-2)
+	{
+		printPageButton($maxPage, False);
+	}
+	if ($sortBar)
+	{
+		print '<span style="float:right;">
+			<FORM class="advancedSearch" method="get" action="board.php#results">
+			<b>Country:</b>
+			<select  class = "advancedSearch" name="msgFilter">
+				<option'.(($msgFilter==-1) ? ' selected="selected"' : '').' value=-1>All</option>';
+				for( $countryID=0; $countryID<=count($Game->Variant->countries); $countryID++)
+				{
+					if( isset($Member) )
+					{
+						if ( $countryID == $Member->countryID )
+						{
+							print '<option'.(($msgFilter == $countryID) ? ' selected="selected"' : '').' value='.$countryID.'>Notes</option>';
+						}
+						elseif(isset($Game->Members->ByCountryID[$countryID]))
+						{
+							print '<option'.(($msgFilter == $countryID) ? ' selected="selected"' : '').' value='.$countryID.'>'.$Game->Members->ByCountryID[$countryID]->memberCountryName().'</option>';
+						}
+						else
+						{
+							print '<option'.(($msgFilter==0) ? ' selected="selected"' : '').' value=0>Global</option>';
+						}
+					}
+				}
+			print '</select>';
+			foreach($_REQUEST as $key => $value)
+			{
+				if(strpos('x'.$key,'wD') == false && strpos('x'.$key,'phpbb3') == false && strpos('x'.$key,'__utm')== false && $key!="pagenum" && $key!="msgFilter")
+				{
+					print '<input type="hidden" name="'.$key.'" value='.$value.'>';
+				}
+			}
+			print ' ';
+			print '<input type="submit" class="form-submit" name="Submit" value="Refresh" /></form>
+			</span>';
+		}
+}
+
+function printPageButton($pagenum, $currPage)
+{
+	if ($currPage)
+	{
+		print '<div class="curr-page">'.$pagenum.'</div>';
+	}
+	else
+	{
+		print '<div style="display:inline-block; margin:3px;">';
+		print '<FORM method="get" action=board.php#results>';
+		foreach($_REQUEST as $key => $value)
+		{
+			if(strpos('x'.$key,'wD') == false && strpos('x'.$key,'phpbb3')== false && strpos('x'.$key,'__utm')== false && $key!="pagenum")
+			{
+				print '<input type="hidden" name="'.$key.'" value='.$value.'>';
+			}
+		}
+		print '<input type="submit" name="pagenum" class="form-submit" value='.$pagenum.' /></form></div>';
+	}
+}
 
 ?>


### PR DESCRIPTION
Redoes the paging for archived messages in a game to be uniform with the other paging changes made recently. Also adds an option in the archived messages to filter down to just a single country, or global, or notes.

Also fixes issue https://github.com/kestasjk/webDiplomacy/issues/200 from 2015, after realizing that the messaging ordering gets switched several times in order to display the recent messages in the correct place.