### PR TITLE
Missing ";" prevented a clean fullinstall

### DIFF
--- a/install/FullInstall/fullInstall.sql
+++ b/install/FullInstall/fullInstall.sql
@@ -770,7 +770,7 @@ CREATE TABLE `wD_Config` (
   `name` enum('Notice','Panic','Maintenance') NOT NULL,
   `message` text NOT NULL,
   PRIMARY KEY (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 INSERT INTO wD_Config VALUES ('Notice','Default server-wide notice message.'),('Panic','Game processing has been paused and user registration has been disabled while a problem is resolved.'),('Maintenance','Server is in maintenance mode; only admins can fully interact with the server.'),('ServerOffline','');
 


### PR DESCRIPTION
Small error I found during the setup of my new webdip installation.