### PR TITLE
Removed Tournaments Info from header, linked on Tournament tool

### DIFF
--- a/contactUsDirect.php
+++ b/contactUsDirect.php
@@ -450,7 +450,8 @@ else
     print '<div id="ifEmergency" style="display:none">';
     print '<p> <font color="red">This is for personal emergencies only and will instantly pause all of your running games that you are not defeated in. The
     moderator team will give you 7 days to let us know when you expect to be back. If we do not hear back in 7 days we will look for a replacement. <br><br>
-    Abuse will be punished with a 50% point dock at minimum. <strong>Vacations do not count as a personal emergency.</strong></font></br></br>
+    <strong>Vacations, business trips, or any other absence you know of ahead of time do not count as a personal emergency.</strong> This tool is intended for unexpected absences, such as a family emergency, widespread power outage, natural disaster, or other circumstance you cannot plan for. If you can plan for your pause ahead of time, it is not an emergency. You should inform others in your game in advance that you will need a pause, and if you cannot do so instead contact the moderators at' .Config::$modEMail;'.</font></br></br>
+    Abuse of the emergency pause will be punished with a 50% point dock and removal of your emergency pause privilege at minimum. <br><br>
     Using your emergency pause will instantly pause the following games: ';
     
     $counter = 1;

--- a/lib/html.php
+++ b/lib/html.php
@@ -837,7 +837,6 @@ class libHTML
 							<a href="gamecreate.php" title="Start up a new game">Create a New Game</a>
 							<a href="https://sites.google.com/view/webdipinfo/ghost-ratings" target=_blank title="Ghost Ratings (external site)">Ghost Ratings</a>
 							<a href="tournaments.php" title="Information about tournaments on webDiplomacy">Tournaments</a>
-							<a href="tournamentInfo.php" title="Information about tournaments on webDiplomacy">Tournament info</a>
 							<a href="halloffame.php" title="Information about tournaments on webDiplomacy">Hall of Fame</a>
                         </div>
                     </div>

--- a/locales/English/faq.php
+++ b/locales/English/faq.php
@@ -214,7 +214,7 @@ from the moderators explaining what happened, how long it will persist, and what
 
 "Miscellaneous" => "Sub-section",
 
-"Do you have colorblind friendly maps?" => "We have several colorblind options available in the <a href='settings.php' class='light'>account settings page</a>. These settings
+"Do you have colorblind friendly maps?" => "We have several colorblind options available in the <a href='usercp.php' class='light'>account settings page</a>. These settings
 only work on the small map in games currently. Currently we have support for Protanope, Deuteranope, and Tritanope.",
 
 "What are the Ghost Ratings?" => "The Ghost Ratings were developed by TheGhostmaker as an alternative scoring system to points on webDiplomacy. 

--- a/tournaments.php
+++ b/tournaments.php
@@ -108,6 +108,8 @@ foreach($tabs as $tabChoice=>$tabTitle)
 }
 
 print '</div>';
+print '<br/><div style="text-align:center">
+    For detailed information on how tournaments work on webDiplomacy, click <a href="tournamentInfo.php">here</a>.</div>';
 
 libHTML::pagebreak();
 


### PR DESCRIPTION
Link on tournaments.php goes to tournamentInfo.php. Forum header needs to be adjusted.