### PR TITLE
Fix the display of HTMLcode in the final map of a game.

### DIFF
--- a/map/drawMap.php
+++ b/map/drawMap.php
@@ -533,6 +533,7 @@ abstract class drawMap
 	 */
 	protected function drawText($text, $x, $y, $large=false, $topRight=false)
 	{
+		$text = html_entity_decode($text);
 		$size = ( $large ? 'largeSize' : 'size' );
 
 		$boundingBox = imageftbbox($this->font[$size],


### PR DESCRIPTION
Small fix to display the correct font instead of HTML-code in the final map of a game.