### PR TITLE
Adjust RR for Live Games

### DIFF
--- a/admin/adminActions.php
+++ b/admin/adminActions.php
@@ -1178,13 +1178,16 @@ class adminActions extends adminActionsForms
 		 
 		$year = time() - 31536000;
 		$lastMonth = time() - 2419200;
+		$lastWeek = time() - 604800;
 
 		$RELIABILITY_QUERY = "
 		UPDATE wD_Users u 
 		set u.reliabilityRating = greatest(0, 
 		(100 *(1 - ((SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.modExcused = 0 and t.turnDateTime > ".$year.") / greatest(1,u.yearlyPhaseCount))))
-		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastMonth."))
-		-(5*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$year.")))
+		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 0 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastMonth."))
+		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 1 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastWeek."))
+		-(5*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 1 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastMonth."))
+		-(5*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 0 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$year.")))
 		where u.id = ".$userIDtoUpdate;
 
 		$DB->sql_put($RELIABILITY_QUERY);

--- a/gamemaster/game.php
+++ b/gamemaster/game.php
@@ -446,7 +446,7 @@ class processGame extends Game
 			if ($this->phaseMinutes > 60)
 			{
 				// Insert a Missed Turn for anyone who missed the turn, accounting for systemExcused and samePeriodExcused
-				$DB->sql_put("INSERT INTO wD_MissedTurns (gameID, userID, countryID, turn, bet, SCCount, forcedByMod, systemExcused, modExcused, turnDateTime, modExcusedReason, samePeriodExcused)
+				$DB->sql_put("INSERT INTO wD_MissedTurns (gameID, userID, countryID, turn, bet, SCCount, forcedByMod, systemExcused, modExcused, turnDateTime, modExcusedReason, samePeriodExcused, liveGame)
 						SELECT m.gameID, m.userID, m.countryID, ".$this->turn." as turn, m.bet, m.supplyCenterNo, 0, CASE WHEN excusedMissedTurns > 0 THEN 1 ELSE 0 END, 0,".time().",'', 
 						CASE WHEN (
 							SELECT COUNT(1) 
@@ -456,7 +456,8 @@ class processGame extends Game
 								AND systemExcused = 0 
 								AND modExcused = 0 
 								AND samePeriodExcused = 0
-						) > 0 THEN 1 ELSE 0 END 
+						) > 0 THEN 1 ELSE 0 END, 
+						0
 						FROM wD_Members m
 						WHERE m.id IN ( ".implode(',',$nmrs).")");
 			}
@@ -464,8 +465,8 @@ class processGame extends Game
 			else
 			{
 				// Insert a Missed Turn for anyone who missed the turn, accounting for systemExcused and samePeriodExcused
-				$DB->sql_put("INSERT INTO wD_MissedTurns (gameID, userID, countryID, turn, bet, SCCount, forcedByMod, systemExcused, modExcused, turnDateTime, modExcusedReason, samePeriodExcused)
-						SELECT m.gameID, m.userID, m.countryID, ".$this->turn." as turn, m.bet, m.supplyCenterNo, 0, CASE WHEN excusedMissedTurns > 0 THEN 1 ELSE 0 END, 0,".time().",'', 0
+				$DB->sql_put("INSERT INTO wD_MissedTurns (gameID, userID, countryID, turn, bet, SCCount, forcedByMod, systemExcused, modExcused, turnDateTime, modExcusedReason, samePeriodExcused, liveGame)
+						SELECT m.gameID, m.userID, m.countryID, ".$this->turn." as turn, m.bet, m.supplyCenterNo, 0, CASE WHEN excusedMissedTurns > 0 THEN 1 ELSE 0 END, 0,".time().",'', 0, 1
 						FROM wD_Members m
 						WHERE m.id IN ( ".implode(',',$nmrs).")");
 			}

--- a/gamemaster/gamemaster.php
+++ b/gamemaster/gamemaster.php
@@ -103,13 +103,16 @@ class libGameMaster
 
 		$year = time() - 31536000;
 		$lastMonth = time() - 2419200;
+		$last2Weeks = time() - 1209600;
 
 		$RELIABILITY_QUERY = "
 		UPDATE wD_Users u 
 		set u.reliabilityRating = greatest(0, 
 		(100 *(1 - ((SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.modExcused = 0 and t.turnDateTime > ".$year.") / greatest(1,u.yearlyPhaseCount))))
-		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastMonth."))
-		-(5*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$year.")))";
+		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 0 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastMonth."))
+		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 1 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$last2Weeks."))
+		-(5*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 1 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastMonth."))
+		-(5*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 0 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$year.")))";
 			
 		// Calculates the RR for members. 
 		$DB->sql_put($RELIABILITY_QUERY. ($recalculateAll ? "" : " WHERE u.timeLastSessionEnded+(30*86400) > ".$Misc->LastProcessTime));

--- a/gamemaster/gamemaster.php
+++ b/gamemaster/gamemaster.php
@@ -103,14 +103,14 @@ class libGameMaster
 
 		$year = time() - 31536000;
 		$lastMonth = time() - 2419200;
-		$last2Weeks = time() - 1209600;
+		$lastWeek = time() - 604800;
 
 		$RELIABILITY_QUERY = "
 		UPDATE wD_Users u 
 		set u.reliabilityRating = greatest(0, 
 		(100 *(1 - ((SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.modExcused = 0 and t.turnDateTime > ".$year.") / greatest(1,u.yearlyPhaseCount))))
 		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 0 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastMonth."))
-		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 1 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$last2Weeks."))
+		-(6*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 1 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastWeek."))
 		-(5*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 1 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$lastMonth."))
 		-(5*(SELECT COUNT(1) FROM wD_MissedTurns t  WHERE t.userID = u.id AND t.liveGame = 0 AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".$year.")))";
 			

--- a/install/1.55-1.56/readme.txt
+++ b/install/1.55-1.56/readme.txt
@@ -1,0 +1,3 @@
+Changelog
+---------
+* Add a check to see if the excused missed turn was from a live game. 

--- a/install/1.55-1.56/update.sql
+++ b/install/1.55-1.56/update.sql
@@ -1,0 +1,5 @@
+UPDATE `wD_Misc` SET `value` = '156' WHERE `name` = 'Version';
+
+ALTER TABLE `wD_MissedTurns` ADD `liveGame` BOOLEAN DEFAULT 0;  
+
+update wD_MissedTurns m inner join wD_Games g on g.id = m.gameID set m.liveGame = 1 where g.phaseMinutes < 61 and g.id is not null;

--- a/objects/user.php
+++ b/objects/user.php
@@ -1195,33 +1195,69 @@ class User {
 	public function getYearlyUnExcusedMissedTurns() 
 	{
 		global $DB;
-		list($totalMissedTurns) = $DB->sql_row("
-		SELECT COUNT(1) FROM wD_MissedTurns t  
-		WHERE t.userID = ".$this->id." AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".(time() - 31536000));
+		list($totalNonLiveMissedTurns) = $DB->sql_row("SELECT COUNT(1) FROM wD_MissedTurns t  
+		WHERE t.userID = ".$this->id." AND t.modExcused = 0 and t.liveGame = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".(time() - 31536000));
 		
-		return $totalMissedTurns;
+		return $totalNonLiveMissedTurns;
 	}
 
 	/*
-	 * Get the number of total non excused missed turns in the past 4 weeks. 
+	 * Get the number of total non excused missed turns from non live in the past 4 weeks. 
 	 */
 	public function getRecentUnExcusedMissedTurns() 
 	{
 		global $DB;
 		list($totalMissedTurns) = $DB->sql_row("SELECT COUNT(1) FROM wD_MissedTurns t  
-			WHERE t.userID = ".$this->id." AND t.modExcused = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".(time() - 2419200));
+			WHERE t.userID = ".$this->id." AND t.modExcused = 0 and t.liveGame = 0 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".(time() - 2419200));
 		
 		return $totalMissedTurns;
 	}
 
 	/*
-	 * Get the number of missed turns in the past year. 
+	 * Get the number of non live missed turns in the past year. 
 	 */
 	public function getMissedTurns() 
 	{
 		global $DB;
 		list($totalMissedTurns) = $DB->sql_row("SELECT COUNT(1) FROM wD_MissedTurns t  
-			WHERE t.userID = ".$this->id." AND t.modExcused = 0 and t.turnDateTime > ".(time() - 2419200));
+			WHERE t.userID = ".$this->id." AND t.liveGame = 0 and t.modExcused = 0 and t.turnDateTime > ".(time() - 31536000));
+		
+		return $totalMissedTurns;
+	}
+
+	/*
+	 * Get the number of non excused live missed turns in the last month. 
+	 */
+	public function getLiveUnExcusedMissedTurns() 
+	{
+		global $DB;
+
+		list($totalLiveMissedTurns) = $DB->sql_row("SELECT COUNT(1) FROM wD_MissedTurns t  
+		WHERE t.userID = ".$this->id." AND t.modExcused = 0 and t.liveGame = 1 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".(time() - 2419200));
+		
+		return $totalLiveMissedTurns;
+	}
+
+	/*
+	 * Get the number of total non excused missed turns from live in the past week. 
+	 */
+	public function getLiveRecentUnExcusedMissedTurns() 
+	{
+		global $DB;
+		list($totalMissedTurns) = $DB->sql_row("SELECT COUNT(1) FROM wD_MissedTurns t  
+			WHERE t.userID = ".$this->id." AND t.modExcused = 0 and t.liveGame = 1 and t.samePeriodExcused = 0 and t.systemExcused = 0 and t.turnDateTime > ".(time() - (86400 * 7)));
+		
+		return $totalMissedTurns;
+	}
+
+	/*
+	 * Get the number of live missed turns in the past month. For live games missed turns are completely forgiven after 1 month
+	 */
+	public function getLiveMissedTurns() 
+	{
+		global $DB;
+		list($totalMissedTurns) = $DB->sql_row("SELECT COUNT(1) FROM wD_MissedTurns t  
+			WHERE t.userID = ".$this->id." AND t.liveGame = 1 and t.modExcused = 0 and t.turnDateTime > ".(time() - 2419200));
 		
 		return $totalMissedTurns;
 	}


### PR DESCRIPTION
Adjust RR so that unexcused missed turns operate differently for live games. Live game players have 3 unexcused missed turns in a 28 day period that can be missed without a temp ban. After that any unexcused missed turn will result in a 24 hour temp ban. Any further after that day are also just 1 day temp bans. RR hits for unexcused missed turns are the same 11%. But for live games the 6% added penalty will vanish in a week, and the remaining 5% will be gone in 28 days. This should help live game players not be impacted as negatively by missed turns. These unexcused missed turns in live games will NOT count against the yearly total for temp bans for normal missed turns. The RR page has been updated to show how this extra penalty works only if you have live games with missed turns. This also includes a migration script to update all missed turns from live games.