### PR TITLE
Reorder "Game stats:" display

### DIFF
--- a/profile.php
+++ b/profile.php
@@ -499,9 +499,11 @@ if( $total )
 	print '<li><strong>'.l_t('All Game stats:').'</strong> </div><div class = "profile_content_show">';
 
 	// Shows each of the game details
-	foreach($rankingDetails['stats'] as $name => $status)
+	foreach($includeStatus as $name)
 	{
-		if ( !in_array($name, $includeStatus) ) continue;
+		if ( !array_key_exists($name, $rankingDetails['stats']) ) continue;
+
+		$status = $rankingDetails['stats'][$name];
 
 		if (!$showAnon && isset($rankingDetails['anon'][$name]))
 			$status -= $rankingDetails['anon'][$name];
@@ -510,6 +512,8 @@ if( $total )
 		print ' ( '.round(($status/$total)*100).'% )';
 		print '</li>';
 	}
+	print '<li>'.l_t('Total (finished): <strong>%s</strong>',$total).'</li>';
+	print '<br>';
 
 	// This shows the Playing/Civil Disorder and CD takeover stats.
 	foreach($rankingDetails['stats'] as $name => $status)
@@ -520,8 +524,8 @@ if( $total )
 			$status -= $rankingDetails['anon'][$name];
 		print '<li>'.l_t($name.': <strong>%s</strong>',$status).'</li>';
 	}
-	print '<li>'.l_t('Total (finished): <strong>%s</strong>',$total).'</li>';
 	print '</li>';
+	print '</div>';
 
 	// Get a count of the number of classic games that have been played.
 	$totalClassic = 0;
@@ -531,16 +535,17 @@ if( $total )
 
 		$totalClassic += $status;
 	}
-	print '</div>';
 
 	// Print out Classic stats if any classic games have been finished.
 	if( $totalClassic )
 	{
 		print '<div class = "profile_title">';
 		print '<li><strong>'.l_t('Classic:').'</strong></div><div class = "profile_content">';
-		foreach($rankingDetailsClassic['stats'] as $name => $status)
+		foreach($includeStatus as $name)
 		{
-			if ( !in_array($name, $includeStatus) ) continue;
+			if ( !array_key_exists($name, $rankingDetailsClassic['stats']) ) continue;
+
+			$status = $rankingDetailsClassic['stats'][$name];
 
 			print '<li>'.l_t($name.': <strong>%s</strong>',$status);
 			print ' ( '.round(($status/$totalClassic)*100).'% )';
@@ -549,7 +554,6 @@ if( $total )
 		print '<li>'.l_t('Total (finished): <strong>%s</strong>',$totalClassic).'</li>';
 		print '</li>';
 		print '</div>';
-		// print '</div>';
 	}
 
 	// Get a count of the number of classic press games that have been played.
@@ -567,9 +571,11 @@ if( $total )
 		print '<div class = "profile_title">';
 		print '<li><strong>'.l_t('Classic Press:').'</strong> </div><div class = "profile_content">';
 
-		foreach($rankingDetailsClassicPress['stats'] as $name => $status)
+		foreach($includeStatus as $name)
 		{
-			if ( !in_array($name, $includeStatus) ) continue;
+			if ( !array_key_exists($name, $rankingDetailsClassicPress['stats']) ) continue;
+
+			$status = $rankingDetailsClassicPress['stats'][$name];
 
 			print '<li>'.l_t($name.': <strong>%s</strong>',$status);
 			print ' ( '.round(($status/$totalClassicPress)*100).'% )';
@@ -595,9 +601,11 @@ if( $total )
 		print '<div class = "profile_title">';
 		print '<li><strong>'.l_t('Classic Gunboat:').'</strong> </div><div class = "profile_content">';
 
-		foreach($rankingDetailsClassicGunboat['stats'] as $name => $status)
+		foreach($includeStatus as $name)
 		{
-			if ( !in_array($name, $includeStatus) ) continue;
+			if ( !array_key_exists($name, $rankingDetailsClassicGunboat['stats']) ) continue;
+
+			$status = $rankingDetailsClassicGunboat['stats'][$name];
 
 			print '<li>'.l_t($name.': <strong>%s</strong>',$status);
 			print ' ( '.round(($status/$totalClassicGunboat)*100).'% )';
@@ -623,9 +631,11 @@ if( $total )
 		print '<div class = "profile_title">';
 		print '<li><strong>'.l_t('Classic Ranked:').'</strong> </div><div class = "profile_content">';
 
-		foreach($rankingDetailsClassicRanked['stats'] as $name => $status)
+		foreach($includeStatus as $name)
 		{
-			if ( !in_array($name, $includeStatus) ) continue;
+			if ( !array_key_exists($name, $rankingDetailsClassicRanked['stats']) ) continue;
+
+			$status = $rankingDetailsClassicRanked['stats'][$name];
 
 			print '<li>'.l_t($name.': <strong>%s</strong>',$status);
 			print ' ( '.round(($status/$totalClassicRanked)*100).'% )';
@@ -651,9 +661,11 @@ if( $total )
 		print '<div class = "profile_title">';
 		print '<li><strong>'.l_t('Variant stats:').'</strong> </div> <div class = "profile_content">';
 
-		foreach($rankingDetailsVariants['stats'] as $name => $status)
+		foreach($includeStatus as $name)
 		{
-			if ( !in_array($name, $includeStatus) ) continue;
+			if ( !array_key_exists($name, $rankingDetailsVariants['stats']) ) continue;
+
+			$status = $rankingDetailsVariants['stats'][$name];
 
 			print '<li>'.l_t($name.': <strong>%s</strong>',$status);
 			print ' ( '.round(($status/$totalVariants)*100).'% )';


### PR DESCRIPTION
Issue #210

Reorder the game stats display to more accurately display
the stats that show how good a player is at the game.

The new order:
Wins > Draws > Survivals > Defeats

Playing, Civil Disorders, and Civil Disorders taken over are in a separate grouping as they don't directly reflect on a player's skill, more their reliability.