### PR TITLE
Fix for problems with convoy code in phaseDiplomacy.js

### DIFF
--- a/javascript/board/model.js
+++ b/javascript/board/model.js
@@ -166,6 +166,8 @@ function loadModel() {
 				{
 					this.convoyOptions=this.ConvoyGroup.Coasts.select(this.canConvoyTo, this).pluck('id');
 					choices=snapTogether(choices,this.convoyOptions).uniq();
+				} else {
+					this.convoyOptions = []
 				}
 				
 				return choices;
@@ -221,6 +223,8 @@ function loadModel() {
 					this.convoyOptions=AgainstTerritory.ConvoyGroup.Armies.pluck('Territory').pluck('id');
 					
 					PossibleUnits=snapTogether(PossibleUnits,ConvoyArmies);
+				} else {
+					this.convoyOptions = []
 				}
 				
 				// Return names, excluding the current territory
@@ -252,10 +256,11 @@ function loadModel() {
 							return true;
 						
 					},this).pluck('Territory').pluck('id');
-					return this.convoyOptions;
 				}
 				else
-					return [ ];
+					this.convoyOptions = []
+					
+				return this.convoyOptions;
 			}
 		});
 		

--- a/javascript/orders/phaseDiplomacy.js
+++ b/javascript/orders/phaseDiplomacy.js
@@ -28,7 +28,7 @@ function loadOrdersPhase() {
 				
 				var convoyPath = $A([ ]);
 				
-				if( this.isComplete && !Object.isUndefined(this.Unit.convoyOptions) )
+				if( this.isComplete )
 				{
 					if( this.type=='Move' && this.Unit.convoyOptions.any(function(c){ return (c==this.toTerrID); },this) )
 					{


### PR DESCRIPTION
This is fix to a similar issue as in #357 which leads to the JS code crashing when orders involving convoy paths are set in a certain order in certain situations. This temporary locks the Ready-Button on WebDip. On vdip, the Save-Button is locked, too, making the bug more visible over there.

**Steps to reproduce the problem:**
I encountered one way today, when I entered first A Ser S A Rum -> Bul (while there was a fleet in BLA) and after that I changed the order to A Ser -> Rum.

**Cause:**
As in #357 the cause is related to the code in javascript/orders/phaseDiplomacy.js that checks if a convoy path has to be provided to the server. In that part of the code, the variable Unit.convoyOptions is used to determine if the set order can only be fulfilled for a convoyed unit. In that case a convoy path has to be passed to the server-side validator. However, a convoy path is needed for different orders, fulfilling different roles there.  For a "Move"  the passed convoy path describes the own convoy path the target while for a "Support move"  the convoy path describes the path of the supported unit. Finally for a "Convoy" the convoy path relates to the path of the convoyed unit.
During the setting of the order, the convoy options are created. As with the convoy path the convoy options take different values depending on the order type. For a "Move", the convoy options are all move options that could or need to use a convoy. For a "Support move", the convoy options contain the support move from options for which the selected support move to choice might be reached via convoy in the actual move. And for the "Convoy" it lists the possible targets of the unit to be convoyed.
The problem is, that so far the convoy options are only updated, if a new order is set, that actually has such convoy options. However, the phaseDiplomacy.js code assumes that the convoy options are up to date with the current order type. Based on that assumption, code might be executed that leads to a crash in that specific case.

In the given example, convoy options are first created when Serbia supports a move to Rumania as there is a fleet in BLA that generates support move from choices with a convoy. However, when I choose A Ser -> Rum, the convoy choices are neither updated nor deleted. phaseDiplomacy.js then assumes that the outdated convoy options actually list convoy options for the move and (as you can see in code) try to determine a convoy path to Rumania by calling the Convoy Group that an army with convoy options would be part of. However, as Serbia is inland, there is no convoy group and the code crashes.

**Fix:**
As a fix I just added code, so the convoy options are always updated with new "Move", "Support Move" and "Convoy" orders. So if there are no convoy options for a "Move", "Support Move From" or "Convoy", the convoy options are actually updated to an empty array instead of risking to leave an outdated list behind that serves no purpose any longer.

**Testing:**
I did some manual test cases that included most of the situations that could appear. Just to make sure, I did not make some dumb typing error or something. Given the simplicity of the changes in this fix, that should probably be enough.