### PR TITLE
API - Only returned powers who are still playing

### DIFF
--- a/api/responses/unordered_countries.php
+++ b/api/responses/unordered_countries.php
@@ -55,13 +55,14 @@ class UnorderedCountries {
         // Finds powers (gameID, countryID) that
         // 1) Are played by the user linked to the API key making the request (m.userID = $userID)
         // 2) On a map (and a gameID) that is supported by the API
-        // 3) Where orders have not yet been submitted (orderStatus is NULL or '')
+        // 3) Where orders have not yet been submitted (orderStatus is NULL or '') and player is playing (not defeated)
         // 4) Only if the game is still active (i.e. not pre-game, finished, paused, etc.)
 
 		$countryTabl = $DB->sql_tabl("SELECT m.gameID, m.countryID
                                       FROM wD_Members AS m
                                       LEFT JOIN wD_Games AS g ON ( g.id = m.gameID )
                                       WHERE (m.orderStatus IS NULL OR m.orderStatus = '')
+                                            AND m.status = 'Playing'
                                             AND m.userID = $userID
                                             AND g.variantID in ($apiVariants)
                                             " . $filterGameClause . "


### PR DESCRIPTION
The API indicates that defeated powers are missing orders, so the bot needs to retrieve the game to figure out that the power has no orderable locations.

This PR fixes the issue by only returning 'Playing' powers.