### PR TITLE
API - CD bug

### DIFF
--- a/api.php
+++ b/api.php
@@ -657,7 +657,11 @@ class ApiKey {
 			// If game ID is required, then user must be member of this game.
 			// Otherwise, any user can call this function.
 			if ($apiEntry->requiresGameID() && !isset($apiEntry->getAssociatedGame()->Members->ByUserID[$this->userID]))
-				throw new ClientForbiddenException('Access denied. User is not member of associated game.');
+				throw new ClientForbiddenException(sprintf(
+					"Access denied. User is not member of associated game. - API Key: %s - Game ID: %s - User ID: %s",
+					substr($this->apiKey, 0, 8),
+					$apiEntry->getAssociatedGame()->id,
+					$this->userID));
 		} else {
 			// Permission field available.
 			if (!in_array($permissionField, ApiKey::$permissionFields))
@@ -669,10 +673,19 @@ class ApiKey {
 				$permissionIsExplicit = true;
 			} else {
 				if (!$apiEntry->requiresGameID())
-					throw new ClientForbiddenException("Permission denied.");
+					throw new ClientForbiddenException(sprintf(
+						"Permission denied. - API Key: %s - UserID: %s - Missing permission: %s",
+						substr($this->apiKey, 0, 8),
+						$this->userID,
+						$permissionField));
 
 				if (!isset($apiEntry->getAssociatedGame()->Members->ByUserID[$this->userID]))
-					throw new ClientForbiddenException('Permission denied, and user is not member of associated game.');
+					throw new ClientForbiddenException(sprintf(
+						"Permission denied, and user is not member of associated game. - API Key: %s - Game ID: %s - User ID: %s - Missing permission: %s",
+						substr($this->apiKey, 0, 8),
+						$apiEntry->getAssociatedGame()->id,
+						$this->userID,
+						$permissionField));
 			}
 		}
 

--- a/api.php
+++ b/api.php
@@ -385,11 +385,6 @@ class SetOrders extends ApiEntry {
 			if ($member->status != 'Left')
 				throw new ClientForbiddenException(
 					'A user not controlling a country can submit orders only for a country in CD.');
-			// We must have enough time to set orders.
-			$currentTime = time();
-			if (($currentTime + 60) < $game->processTime) {
-				throw new RequestException('Process time is not close enough (current time ' . $currentTime . ', process time ' . $game->processTime . ').');
-			}
 		}
 
 

--- a/api/responses/members_in_cd.php
+++ b/api/responses/members_in_cd.php
@@ -64,7 +64,6 @@ class CountriesInCivilDisorder {
         // 3) Only if the power has not logged in during the turn (missedPhases > 0) or is in CD (status = Left)
         // 4) Only if orders have not yet been submitted (orderStatus is NULL or '')
         // 5) Only if the game is still active (i.e. not pre-game, finished, paused, etc.)
-        // 6) And only if the next process() is within the next 60 seconds
 
 		$countryTabl = $DB->sql_tabl("SELECT DISTINCT m.gameID, m.countryID
                                       FROM wD_Members AS m
@@ -77,9 +76,7 @@ class CountriesInCivilDisorder {
                                             AND m.status = 'Left'
                                             AND (m.orderStatus IS NULL OR m.orderStatus = '')
                                             AND g.processStatus = 'Not-processing'
-                                            AND g.phase IN ('Diplomacy', 'Retreats', 'Builds')
-                                            AND g.processTime >= ".time()."
-                                            AND g.processTime <= ".(time() + 60).";");
+                                            AND g.phase IN ('Diplomacy', 'Retreats', 'Builds');");
 
         while( $row = $DB->tabl_hash($countryTabl) )
         {


### PR DESCRIPTION
There seems to be a bug/permission issue for users in CD.

```
2019-09-08 02:49:34 diplomacy.integration.webdiplomacy_net.api[10] INFO [245972/W1906A/AUSTRIA] - Submitting orders: ['A ALB D']
2019-09-08 02:49:34 diplomacy.integration.webdiplomacy_net.api[10] WARNING ERROR during "game/orders". Error code: 403. Body: b'Permission denied, and user is not member of associated game.'.

2019-09-08 02:54:37 diplomacy.integration.webdiplomacy_net.api[10] INFO [245972/S1907M/AUSTRIA] - Submitting orders: ['A GAL - VIE', 'A BUD S A GAL - VIE']
2019-09-08 02:54:37 diplomacy.integration.webdiplomacy_net.api[10] WARNING ERROR during "game/orders". Error code: 403. Body: b'Permission denied, and user is not member of associated game.'.
```

This could be caused by the permission "submitOrdersForUserInCD" not being set on userID 108388 (API key: "MHRo01L...")

This PR:

1) Returns additional details on why the client forbidden exception was thrown, so we know what API key triggered the error on what game.

2) Allows the bot to submit orders for a power in CD anytime the power has the status "Left", as opposed to only 60 secs before the next process time. This means the bot will submit orders as soon as a player is in CD, and if someone takes over, he will be able to modify the orders.

We'll also need to test this further when it is merged. I'm not able to reproduce the issue on my side.