### PR TITLE
Deadlock bug

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -97,39 +97,39 @@ elseif( isset($_REQUEST['context']) && isset($_REQUEST['contextKey']) && isset($
 
 		$results = $O->getResults();
 
-		if( $newReady && !$oldReady )
-		{
-			$results['process']='Checked';
-
-			$Game = libVariant::$Variant->Game($O->gameID);
-
-			if( $Game->processStatus!='Crashed' && $Game->attempts > count($Game->Members->ByID)*2 )
-			{
-				$DB->sql_put("COMMIT");
-				require_once(l_r('gamemaster/game.php'));
-				$Game =libVariant::$Variant->processGame($Game->id);
-				$Game->crashed();
-				$DB->sql_put("COMMIT");
-			}
-			elseif( $Game->needsProcess() )
-			{
-				$DB->sql_put("UPDATE wD_Games SET attempts=attempts+1 WHERE id=".$Game->id);
-				$DB->sql_put("COMMIT");
-
-				$results['process']='Attempted';
-
-				require_once(l_r('gamemaster/game.php'));
-				$Game = libVariant::$Variant->processGame($O->gameID);
-				if( $Game->needsProcess() )
-				{
-					$Game->process();
-					$DB->sql_put("UPDATE wD_Games SET attempts=0 WHERE id=".$Game->id);
-					$DB->sql_put("COMMIT");
-					$results['process']='Success';
-					$results['notice']=l_t('Game processed, click <a href="%s">here</a> to refresh..','board.php?gameID='.$Game->id.'&nocache='.rand(0,1000));
-				}
-			}
-		}
+		// if( $newReady && !$oldReady )
+        // {
+        // 	$results['process']='Checked';
+        //
+        // 	$Game = libVariant::$Variant->Game($O->gameID);
+        //
+        // 	if( $Game->processStatus!='Crashed' && $Game->attempts > count($Game->Members->ByID)*2 )
+        // 	{
+        // 		$DB->sql_put("COMMIT");
+        // 		require_once(l_r('gamemaster/game.php'));
+        // 		$Game =libVariant::$Variant->processGame($Game->id);
+        // 		$Game->crashed();
+        // 		$DB->sql_put("COMMIT");
+        // 	}
+        // 	elseif( $Game->needsProcess() )
+        // 	{
+        // 		$DB->sql_put("UPDATE wD_Games SET attempts=attempts+1 WHERE id=".$Game->id);
+        // 		$DB->sql_put("COMMIT");
+        //
+        // 		$results['process']='Attempted';
+        //
+        // 		require_once(l_r('gamemaster/game.php'));
+        // 		$Game = libVariant::$Variant->processGame($O->gameID);
+        // 		if( $Game->needsProcess() )
+        // 		{
+        // 			$Game->process();
+        // 			$DB->sql_put("UPDATE wD_Games SET attempts=0 WHERE id=".$Game->id);
+        // 			$DB->sql_put("COMMIT");
+        // 			$results['process']='Success';
+        // 			$results['notice']=l_t('Game processed, click <a href="%s">here</a> to refresh..','board.php?gameID='.$Game->id.'&nocache='.rand(0,1000));
+        // 		}
+        // 	}
+        // }
 	}
 	catch(Exception $e)
 	{

--- a/api.php
+++ b/api.php
@@ -535,38 +535,38 @@ class SetOrders extends ApiEntry {
 		}
 
 		// Processing game
-        if ($orderInterface->orderStatus->Ready && !$previousReadyValue) {
-            require_once(l_r('objects/misc.php'));
-            require_once(l_r('objects/notice.php'));
-            require_once(l_r('objects/user.php'));
-            global $Misc;
-            $Misc = new Misc();
-            $game = $this->getAssociatedGame();
-
-            if( $game->processStatus!='Crashed' && $game->attempts > count($game->Members->ByID)*2 )
-            {
-                $DB->sql_put("COMMIT");
-                require_once(l_r('gamemaster/game.php'));
-
-                $game = libVariant::$Variant->processGame($game->id);
-                $game->crashed();
-                $DB->sql_put("COMMIT");
-            }
-            elseif( $game->needsProcess() )
-            {
-                $DB->sql_put("UPDATE wD_Games SET attempts=attempts+1 WHERE id=".$game->id);
-                $DB->sql_put("COMMIT");
-
-                require_once(l_r('gamemaster/game.php'));
-                $game = libVariant::$Variant->processGame($gameID);
-                if( $game->needsProcess() )
-                {
-                    $game->process();
-                    $DB->sql_put("UPDATE wD_Games SET attempts=0 WHERE id=".$game->id);
-                    $DB->sql_put("COMMIT");
-                }
-            }
-        }
+        // if ($orderInterface->orderStatus->Ready && !$previousReadyValue) {
+        //     require_once(l_r('objects/misc.php'));
+        //     require_once(l_r('objects/notice.php'));
+        //     require_once(l_r('objects/user.php'));
+        //     global $Misc;
+        //     $Misc = new Misc();
+        //     $game = $this->getAssociatedGame();
+        //
+        //     if( $game->processStatus!='Crashed' && $game->attempts > count($game->Members->ByID)*2 )
+        //     {
+        //         $DB->sql_put("COMMIT");
+        //         require_once(l_r('gamemaster/game.php'));
+        //
+        //         $game = libVariant::$Variant->processGame($game->id);
+        //         $game->crashed();
+        //         $DB->sql_put("COMMIT");
+        //     }
+        //     elseif( $game->needsProcess() )
+        //     {
+        //         $DB->sql_put("UPDATE wD_Games SET attempts=attempts+1 WHERE id=".$game->id);
+        //         $DB->sql_put("COMMIT");
+        //
+        //         require_once(l_r('gamemaster/game.php'));
+        //         $game = libVariant::$Variant->processGame($gameID);
+        //         if( $game->needsProcess() )
+        //         {
+        //             $game->process();
+        //             $DB->sql_put("UPDATE wD_Games SET attempts=0 WHERE id=".$game->id);
+        //             $DB->sql_put("COMMIT");
+        //         }
+        //     }
+        // }
 
         // Returning current orders
 		return json_encode($currentOrders);

--- a/board.php
+++ b/board.php
@@ -197,36 +197,36 @@ if( isset($Member) && $Member->status == 'Playing' && $Game->phase!='Finished' )
 				throw $e;
 			}
 		}
-		else if( $Game->needsProcess() )
-		{
-			$DB->sql_put("UPDATE wD_Games SET attempts=attempts+1 WHERE id=".$Game->id);
-			$DB->sql_put("COMMIT");
-
-			require_once(l_r('gamemaster/game.php'));
-			$Game = $Game->Variant->processGame($Game->id);
-			if( $Game->needsProcess() )
-			{
-				try
-				{
-					$Game->process();
-					$DB->sql_put("UPDATE wD_Games SET attempts=0 WHERE id=".$Game->id);
-					$DB->sql_put("COMMIT");
-				}
-				catch(Exception $e)
-				{
-					if( $e->getMessage() == "Abandoned" || $e->getMessage() == "Cancelled" )
-					{
-						assert('$Game->phase=="Pre-game" || $e->getMessage() == "Cancelled"');
-						$DB->sql_put("COMMIT");
-						libHTML::notice(l_t('Cancelled'), l_t("Game was cancelled or didn't have enough players to start."));
-					}
-					else
-						$DB->sql_put("ROLLBACK");
-
-					throw $e;
-				}
-			}
-		}
+		// else if( $Game->needsProcess() )
+		// {
+		// 	$DB->sql_put("UPDATE wD_Games SET attempts=attempts+1 WHERE id=".$Game->id);
+		// 	$DB->sql_put("COMMIT");
+		//
+		// 	require_once(l_r('gamemaster/game.php'));
+		// 	$Game = $Game->Variant->processGame($Game->id);
+		// 	if( $Game->needsProcess() )
+		// 	{
+		// 		try
+		// 		{
+		// 			$Game->process();
+		// 			$DB->sql_put("UPDATE wD_Games SET attempts=0 WHERE id=".$Game->id);
+		// 			$DB->sql_put("COMMIT");
+		// 		}
+		// 		catch(Exception $e)
+		// 		{
+		// 			if( $e->getMessage() == "Abandoned" || $e->getMessage() == "Cancelled" )
+		// 			{
+		// 				assert('$Game->phase=="Pre-game" || $e->getMessage() == "Cancelled"');
+		// 				$DB->sql_put("COMMIT");
+		// 				libHTML::notice(l_t('Cancelled'), l_t("Game was cancelled or didn't have enough players to start."));
+		// 			}
+		// 			else
+		// 				$DB->sql_put("ROLLBACK");
+		//
+		// 			throw $e;
+		// 		}
+		// 	}
+		// }
 	}
 
 	if( $Game instanceof processGame )


### PR DESCRIPTION
@kestasjk @jmo1121109

My best guess is that there are deadlocks in the mySQL database, which hangs the server and crashes the site.

I got this in my logs:
```
<b>Warning</b>:  mysqli_query(): (40001/1213): Deadlock found when trying to get lock; try restarting transaction in <b>/var/www/webdiplomacy.net/public_html/objects/database.php</b> on line <b>375</b><br />
<b>Notice</b>:  Deadlock found when trying to get lock; try restarting transaction in <b>/var/www/webdiplomacy.net/public_html/objects/database.php</b> on line <b>377</b><br />
```

Simple fix is to force all adjudication to happen through gamemaster.php, so games are processed sequentially. This should at least avoid processing multiple games at the same time, which is one the likely causes of the deadlock.

Let me know your thoughts.