### PR TITLE
Fix bot voting

### DIFF
--- a/gamemaster/game.php
+++ b/gamemaster/game.php
@@ -711,7 +711,6 @@ class processGame extends Game
 		
 		$this->Members->updateReliabilityStats();
 		
-		
 		//Applies any votes for bot games anytime the phase changes - needed for forced draws.
 		if ($this->playerTypes <> 'Members')
 		{
@@ -720,8 +719,6 @@ class processGame extends Game
 			foreach($this->Members->ByStatus['Playing'] as $Member)
 			{
 				$userPassed = new User($Member->userID);
-	
-				//Bot votes are handled differently
 				if($userPassed->type['Bot']) 
 				{
 					$botCount += 1;

--- a/gamemaster/game.php
+++ b/gamemaster/game.php
@@ -710,6 +710,28 @@ class processGame extends Game
 		}
 		
 		$this->Members->updateReliabilityStats();
+		
+		
+		//Applies any votes for bot games anytime the phase changes - needed for forced draws.
+		if ($this->playerTypes <> 'Members')
+		{
+			$playerCount = count($this->Members->ByStatus['Playing']);
+			$botCount = 0;
+			foreach($this->Members->ByStatus['Playing'] as $Member)
+			{
+				$userPassed = new User($Member->userID);
+	
+				//Bot votes are handled differently
+				if($userPassed->type['Bot']) 
+				{
+					$botCount += 1;
+				}
+			}
+			if ($playerCount == $botCount) 
+			{
+				$this->setDrawn();
+			}
+		}
 	}
 
 	/**

--- a/gamemaster/game.php
+++ b/gamemaster/game.php
@@ -711,8 +711,8 @@ class processGame extends Game
 		
 		$this->Members->updateReliabilityStats();
 		
-		//Applies any votes for bot games anytime the phase changes - needed for forced draws.
-		if ($this->playerTypes <> 'Members')
+		//Anytime the phase changes checks for force draws if only bots are left.
+		if ($this->playerTypes <> 'Members' && $this->phase <> 'Finished' && $this->phase <> 'Pre-game')
 		{
 			$playerCount = count($this->Members->ByStatus['Playing']);
 			$botCount = 0;


### PR DESCRIPTION
The way that votes are applied does not fit very well with bots. This fix will get around this by checking if a game has only bots left every single time the game processes and force drawing the game when appropriate.