### PR TITLE
Fix assertion check to be PHP7+ compatible, fixes #381

### DIFF
--- a/admin/adminStatusLists.php
+++ b/admin/adminStatusLists.php
@@ -33,7 +33,7 @@ if( $User->type['Admin'] )
 {
 	//There may be sensitive info that would allow privilege escalation in these error logs
 
-	print '<p class="modTools"><strong>'.l_t('Error logs:').'</strong> '.libError::stats().' ('.libHTML::admincp('clearErrorLogs',null,'Clear').')</p>';
+	print '<p class="modTools"><strong>'.l_t('Error logs:').'</strong> '.libError::stats().' ('.libHTML::admincp('clearErrorLogs', [],'Clear').')</p>';
 
 	$dir =  libError::directory();
 	$errorlogs = libError::errorTimes();

--- a/board.php
+++ b/board.php
@@ -187,7 +187,7 @@ if( isset($Member) && $Member->status == 'Playing' && $Game->phase!='Finished' )
 			{
 				if( $e->getMessage() == "Abandoned" || $e->getMessage() == "Cancelled" )
 				{
-					assert('$Game->phase=="Pre-game" || $e->getMessage() == "Cancelled"');
+					assert($Game->phase == 'Pre-game' || $e->getMessage() == 'Cancelled');
 					$DB->sql_put("COMMIT");
 					libHTML::notice(l_t('Cancelled'), l_t("Game was cancelled or didn't have enough players to start."));
 				}
@@ -216,7 +216,7 @@ if( isset($Member) && $Member->status == 'Playing' && $Game->phase!='Finished' )
 				{
 					if( $e->getMessage() == "Abandoned" || $e->getMessage() == "Cancelled" )
 					{
-						assert('$Game->phase=="Pre-game" || $e->getMessage() == "Cancelled"');
+						assert($Game->phase == 'Pre-game' || $e->getMessage() == 'Cancelled');
 						$DB->sql_put("COMMIT");
 						libHTML::notice(l_t('Cancelled'), l_t("Game was cancelled or didn't have enough players to start."));
 					}

--- a/board/chatbox.php
+++ b/board/chatbox.php
@@ -83,7 +83,7 @@ class Chatbox
 	 * Post a message to the given countryID, if there is one to be posted. Will also send messages as a
 	 * GameMaster if the user is a moderator which isn't joined into the game.
 	 *
-	 * @param $msgCountryID The countryID to post to, may include 0 (Global)
+	 * @param int $msgCountryID The countryID to post to, may include 0 (Global)
 	 */
 	public function postMessage($msgCountryID)
 	{

--- a/board/orders/diplomacy.php
+++ b/board/orders/diplomacy.php
@@ -53,6 +53,9 @@ class userOrderDiplomacy extends userOrder
 		}
 	}
 
+    /**
+     * @return bool
+     */
 	protected function typeCheck()
 	{
 		switch($this->type) {
@@ -62,8 +65,7 @@ class userOrderDiplomacy extends userOrder
 			case 'Support move':
 				return true;
 			case 'Convoy':
-				if ( $this->Unit->type == 'Fleet' and $this->Unit->Territory->type == 'Sea' )
-					return true;
+			    return $this->Unit->type == 'Fleet' && $this->Unit->Territory->type == 'Sea';
 			default:
 				return false;
 		}

--- a/gamemaster/adjudicator/diplomacy/convoyMove.php
+++ b/gamemaster/adjudicator/diplomacy/convoyMove.php
@@ -43,11 +43,11 @@ class adjConvoyMove extends adjMove
 	 * array which is otherwise full of IDs
 	 *
 	 * @param array $units
-	 * @param unknown_type[optional] $chain The chain getting processed 
+	 * @param array|boolean [optional] $chain The chain getting processed
 	 */
-	public function setUnits(array $units, &$chain=false)
+	public function setUnits(array $units, &$chain = false)
 	{
-		if ( $chain === false )
+		if ($chain === false || !is_array($chain))
 		{
 			if ( is_array($this->convoyChain) )
 			{
@@ -59,14 +59,15 @@ class adjConvoyMove extends adjMove
 			return;
 		}
 		
-		foreach($chain as &$var)
+		foreach ($chain as $var)
 		{
 			// &$var means that the chain is edited, and $var isn't just a copy
 			
-			if ( is_array($var) )
-				$this->setUnits($units, $var); // Convert the sub-array into unit objects
-			else
-				$var = $units[$var]; // Set the ID to be a unit object instead
+			if (is_array($var)) {
+                $this->setUnits($units, $var); // Convert the sub-array into unit objects
+            } else {
+                $var = $units[$var]; // Set the ID to be a unit object instead
+            }
 		}
 	}
 	
@@ -76,15 +77,16 @@ class adjConvoyMove extends adjMove
 		if ( $this->convoyChain === false ) return false;
 		else return $this->checkChain($this->convoyChain);
 	}
-	
-	/**
-	 * A recursive function to check whether the convoy chain is a valid path. Returns
-	 * true if the sub-chain does have a valid path to the destination, false if the
-	 * sub-chain does not
-	 *
-	 * @param array $chain
-	 * @return boolean
-	 */
+
+    /**
+     * A recursive function to check whether the convoy chain is a valid path. Returns
+     * true if the sub-chain does have a valid path to the destination, false if the
+     * sub-chain does not
+     *
+     * @param array $chain
+     * @return boolean
+     * @throws adjParadoxException
+     */
 	private function checkChain($chain)
 	{
 		/*
@@ -157,5 +159,3 @@ class adjConvoyMove extends adjMove
 		else return false;
 	}
 }
-
-?>

--- a/gamemaster/adjudicator/diplomacy/dependencyNode.php
+++ b/gamemaster/adjudicator/diplomacy/dependencyNode.php
@@ -249,7 +249,7 @@ class adjDependencyNode
 			/*
 			 * It's a numeric comparison request
 			 */
-			assert('$decision == "compare"');
+			assert($decision == 'compare');
 
 			/*
 			 * Create a decision name that can be placed on the stack, which will allow us

--- a/gamemaster/adjudicator/pregame.php
+++ b/gamemaster/adjudicator/pregame.php
@@ -132,7 +132,7 @@ class adjudicatorPreGame
 		}
 
 		for($countryID=1; $countryID<=count($Game->Variant->countries); $countryID++)
-			assert('$Game->Members->ByCountryID[$countryID]->countryID==$countryID');
+			assert($Game->Members->ByCountryID[$countryID]->countryID == $countryID);
 	}
 
 	protected function assignTerritories() 
@@ -228,7 +228,7 @@ class adjudicatorPreGame
 		if (count($Game->Members->ByCountryID)==0)
 		{
 			$userCountries = $this->userCountries();// $userCountries[$userID]=$countryID
-			assert('count($userCountries) == count($Game->Variant->countries) && count($userCountries) == count($Game->Members->ByID)');
+			assert(count($userCountries) == count($Game->Variant->countries) && count($userCountries) == count($Game->Members->ByID));
 			$this->assignCountries($userCountries);
 		}
 		

--- a/gamemaster/game.php
+++ b/gamemaster/game.php
@@ -195,7 +195,7 @@ class processGame extends Game
 	 * Restores a game from a backup table, or throws an exception if it isn't in a backup table.
 	 * Will erase the live game before restoring it from backup.
 	 *
-	 * @param $gameID The game ID
+	 * @param int $gameID The game ID
 	 */
 	static function restoreGame($gameID)
 	{

--- a/gamemaster/game.php
+++ b/gamemaster/game.php
@@ -74,7 +74,7 @@ class processGame extends Game
 	 */
 	function applyVotes()
 	{
-		assert('$this->phase != "Finished"');
+		assert($this->phase != 'Finished');
 		if($this->phase != "Pre-game")
 		{
 			$votes = $this->Members->votesPassed();
@@ -119,7 +119,7 @@ class processGame extends Game
 	 */
 	function setAbandoned()
 	{
-		assert('$this->phase != "Finished"');
+		assert($this->phase != 'Finished');
 
 		$this->Members->setAbandoned();
 
@@ -134,7 +134,7 @@ class processGame extends Game
 	 */
 	function setCancelled()
 	{
-		assert('$this->phase != "Finished"');
+		assert($this->phase != 'Finished');
 
 		$this->Members->setCancelled();
 
@@ -358,7 +358,7 @@ class processGame extends Game
 	{
 		global $Misc, $DB;
 
-		assert('$this->processStatus != "Paused"');
+		assert($this->processStatus != 'Paused');
 
 		$this->gamelog('Game crashed');
 

--- a/gamemaster/member.php
+++ b/gamemaster/member.php
@@ -81,10 +81,11 @@ class processMember extends Member
 	/**
 	 * Create a new member record, load it into the Members object, should only occur in a Pre-game setting.
 	 *
-	 * @param $userID The userID
-	 * @param $bet The bet, will throw an exception if the user doesn't have enough
+	 * @param int $userID The userID
+	 * @param string $bet The bet, will throw an exception if the user doesn't have enough
+	 * @param int $countryID
 	 */
-	static function create($userID, $bet, $countryID=0)
+	static function create($userID, $bet, $countryID = 0)
 	{
 		global $DB, $Game;
 

--- a/gamemaster/member.php
+++ b/gamemaster/member.php
@@ -88,7 +88,7 @@ class processMember extends Member
 	{
 		global $DB, $Game;
 
-		assert('$Game instanceof processGame');
+		assert($Game instanceof processGame);
 
 		// It is assumed this is being run within a transaction
 
@@ -161,7 +161,7 @@ class processMember extends Member
 			if( isset($supplementAmount) && $supplementAmount>0 ) $bet -= $supplementAmount;
 		}
 
-		assert('$bet <= $this->Game->pot');
+		assert($bet <= $this->Game->pot);
 
 		User::pointsTransfer($this->userID, 'Cancel', $bet, $this->gameID, $this->id);
 

--- a/gamemaster/members.php
+++ b/gamemaster/members.php
@@ -243,7 +243,7 @@ class processMembers extends Members
 	function setDrawn()
 	{
 		$this->prepareLog();
-		assert('count($this->ByStatus[\'Playing\']) > 0');
+		assert(count($this->ByStatus['Playing']) > 0);
 
 		// Calculate the points each player gets.
 		// These are pre-calculated because if they aren't the pot has to be decreased, and active
@@ -268,7 +268,7 @@ class processMembers extends Members
 	function setConcede()
 	{
 		$this->prepareLog();
-		assert('count($this->ByStatus[\'Playing\']) > 0');
+		assert(count($this->ByStatus['Playing']) > 0);
 
 		foreach($this->ByStatus['Left'] as $Member)
 			$Member->setResigned();
@@ -373,7 +373,7 @@ class processMembers extends Members
 		if( !isset(Config::$pointsLogFile) || !Config::$pointsLogFile )
 			return;
 
-		assert('is_array($this->logBefore);');
+		assert(is_array($this->logBefore));
 
 		$before=$this->logBefore;
 		$after=$this->pointsInfoLog();
@@ -473,7 +473,7 @@ class processMembers extends Members
 		$countryID=(int)$countryID;
 
 		// If we're not locked for UPDATE we can't keep things consistant
-		assert('$this->Game->lockMode == UPDATE');
+		assert($this->Game->lockMode == UPDATE);
 
 		if ( $this->Game->private and md5($password) != $this->Game->password and $password != $this->Game->password )
 			throw new Exception(l_t("The invite code you supplied is incorrect, please try again."));

--- a/gamesearch/searchItems.php
+++ b/gamesearch/searchItems.php
@@ -268,7 +268,7 @@ abstract class searchItemCheckbox extends searchItem
 	
 	protected function setValue($values)
 	{
-		assert('is_array($values)');
+		assert(is_array($values));
 		foreach($this->options as $value=>$option)
 			if(in_array($value,$values))
 				$option->checked=true;
@@ -295,7 +295,7 @@ abstract class searchItemCheckbox extends searchItem
 	
 	function filterInput($input)
 	{
-		assert('is_array($input)');
+		assert(is_array($input));
 		if ( $this->locked ) return;
 		
 		$values=array();

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -190,7 +190,7 @@ class libAuth
 	 */
 	static public function adminUserSwitch(User $User)
 	{
-		assert('$User->type["Admin"]');
+		assert($User->type['Admin']);
 
 		if ( isset($_REQUEST['auid']) )
 		{

--- a/lib/html.php
+++ b/lib/html.php
@@ -291,10 +291,10 @@ class libHTML
 	/**
 	 * A link to an admin control panel action
 	 *
-	 * @param $actionName The name of the action
+	 * @param string $actionName The name of the action
 	 * @param array $args The args in a $name=>$value array
-	 * @param $linkName The name to give the link, the URL is returned if no linkName is given
-	 * @param $confirm Boolean to determine whether the action needs javascript confirmation
+	 * @param string $linkName The name to give the link, the URL is returned if no linkName is given
+	 * @param boolean $confirm Boolean to determine whether the action needs javascript confirmation
 	 * @return string A link URL or an <a href>
 	 */
 	static function admincp($actionName, $args=null, $linkName=null,$confirm=false)
@@ -578,7 +578,7 @@ class libHTML
 	 *
 	 * @return string The notification block HTML
 	 */
-	static public function gameNotifyBlock ()
+	static public function gameNotifyBlock()
 	{
 		global $User, $DB;
 

--- a/lib/variant.php
+++ b/lib/variant.php
@@ -48,8 +48,7 @@ class libVariant {
 	 * For everything in board/* (used by ajax.php and board.php) it can be assumed that only one variant
 	 * will be loaded, so here that variant is defined where it will be globally accessible.
 	 *
-	 * @param Variant $Variant
-	 * @return unknown_type
+	 * @param WDVariant $Variant
 	 */
 	public static function setGlobals(WDVariant $Variant) {
 		if( isset(libVariant::$Variant) )
@@ -91,7 +90,7 @@ class libVariant {
 	/**
 	 * Return a Variant object given a variant ID
 	 * @param int $variantID
-	 * @return Variant
+	 * @return WDVariant
 	 */
 	public static function loadFromVariantID($variantID) {
 		return self::loadFromVariantName( Config::$variants[$variantID] );
@@ -118,7 +117,7 @@ class libVariant {
 	/**
 	 * Return a Variant object given its short name (the preferred/quickest way)
 	 * @param string $variantName
-	 * @return Variant
+	 * @return WDVariant
 	 */
 	public static function loadFromVariantName($variantName) {
 		global $DB, $Misc;
@@ -170,8 +169,8 @@ class libVariant {
 
 	/**
 	 * Return a Variant object corresponding to a game ID. This has to
-	 * @param unknown_type $gameID
-	 * @return unknown_type
+	 * @param int $gameID
+	 * @return WDVariant
 	 */
 	public static function loadFromGameID($gameID) {
 		global $DB;

--- a/map/drawMap.php
+++ b/map/drawMap.php
@@ -341,14 +341,18 @@ abstract class drawMap
 	{
 		foreach($this->orderArrows as &$orderArrow)
 		{
-			foreach($orderArrow as $name => &$param) {
+			foreach($orderArrow as $name => &$param)
+			{
 				if ($name == 'headAngle') $param = M_PI / $param;
 
 				if (!is_array($param)) continue;
 
-				if (count($param) == 3) {
+				if (count($param) == 3)
+				{
 					$param = $this->color($param);
-				} else if (count($param) == 2) {
+				}
+				else if (count($param) == 2)
+				{
 					$param = $param[$this->smallmap ? 0 : 1];
 				}
 			}

--- a/map/drawMap.php
+++ b/map/drawMap.php
@@ -341,17 +341,16 @@ abstract class drawMap
 	{
 		foreach($this->orderArrows as &$orderArrow)
 		{
-			foreach($orderArrow as $name => &$param)
-			{
-				if ( $name == 'headAngle' ) $param = M_PI/$param;
+			foreach($orderArrow as $name => &$param) {
+				if ($name == 'headAngle') $param = M_PI / $param;
 
-				if ( ! is_array($param) ) continue;
+				if (!is_array($param)) continue;
 
-				if ( count($param) == 3 )
+				if (count($param) == 3) {
 					$param = $this->color($param);
-
-				if ( count($param) == 2 )
-					$param = $param[ $this->smallmap ? 0 : 1 ];
+				} else if (count($param) == 2) {
+					$param = $param[$this->smallmap ? 0 : 1];
+				}
 			}
 		}
 	}
@@ -1218,7 +1217,9 @@ abstract class drawMap
 	 * Add the territory names, either with GD FreeType or with the small-map overlay
 	 */
  	public function addTerritoryNames() {
- 		if ( count($this->mapNames) )
+ 		if (empty($this->mapNames)) { $this->mapNames = []; }
+
+ 		if (is_array($this->mapNames) && count($this->mapNames))
 		{
 			$this->mapNames = $this->loadImage($this->mapNames);
 			$this->setTransparancy($this->mapNames);
@@ -1240,5 +1241,3 @@ abstract class drawMap
 		}
  	}
 }
-
-?>

--- a/objects/basic/set.php
+++ b/objects/basic/set.php
@@ -50,7 +50,7 @@ class setMemberOrderStatus extends set {
 
 	/**
 	 * None,Saved,Completed,Ready
-	 * @return unknown_type
+	 * @return string
 	 */
 	function icon() {
 		if( $this->None )

--- a/objects/members.php
+++ b/objects/members.php
@@ -315,7 +315,7 @@ class Members
 
 	function pointsLowestCD()
 	{
-		assert('$this->Game->phase != "Pre-game" && $this->Game->phase != "Finished"');
+		assert($this->Game->phase != 'Pre-game' && $this->Game->phase != 'Finished');
 
 		$pointsLowestCD = false;
 		foreach($this->ByStatus['Left'] as $Member)

--- a/objects/scoringsystem.php
+++ b/objects/scoringsystem.php
@@ -52,7 +52,7 @@ class ScoringPPSC extends ScoringSystem {
              */
             $SCsInPlayCount = (float)$this->Game->Members->supplyCenterCount('Playing');
 
-            assert('$SCsInPlayCount > 0');
+            assert($SCsInPlayCount > 0);
 
             $SCTarget = $this->Game->Variant->supplyCenterTarget;
             foreach($this->Game->Members->ByStatus['Playing'] as $Member)

--- a/objects/user.php
+++ b/objects/user.php
@@ -271,7 +271,7 @@ class User {
 	{
 		global $DB;
 
-		assert('$points >= 0');
+		assert($points >= 0);
 
 		$userPassed = new User($userID);
 

--- a/objects/user.php
+++ b/objects/user.php
@@ -819,7 +819,7 @@ class User {
 	 * 
 	 * @param int $userID The id of the user to be temp banned.
 	 * @param int $days The time of the ban in days.
-	 * @param text $reason The reason for the temp ban.
+	 * @param string $reason The reason for the temp ban.
 	 * @param boolean $overwrite True, if the temp ban value should be overwritten
 	 *		in any case. If false, an existing temp ban might be only extended (for
 	 *		automated temp bans).


### PR DESCRIPTION
> 7.0.0 | assert() is now a language construct and not a function. assertion can now be an expression. The second parameter is now interpreted either as an exception (if a Throwable object is given), or as the description supported from PHP 5.4.8 onwards.

https://www.php.net/manual/en/function.assert.php

Also fixes some reference errors with Countable that show up in PHP 7.2+.