### PR TITLE
Use composer for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ variants/KnownWorld_901/
 ghostRatingData.*
 gr.php
 adminInfo.php
+vendor/

--- a/README.txt
+++ b/README.txt
@@ -55,6 +55,14 @@ Edit config.sample.php to work with your setup, being very careful to read the w
 about security issues. The salts/secrets, errorlog/orderlog directories, can all
 leave your server wide open if you don't set them right. Rename to config.php when ready.
 
+=> Composer
+
+Install Composer via https://getcomposer.org/. Then run:
+
+    composer install
+
+This will install all external dependencies that webDiplomacy uses.
+
 => Log-on
 Once you've set config.php up you can use the random gameMasterSecret you entered
 to authenticate as the admin. First create a user via the registration page, then 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "kestasjk/web-diplomacy",
+  "description": "webDiplomacy",
+  "keywords": ["diplomacy"],
+  "type": "project",
+  "repositories": [],
+  "require": {
+    "php": "^7.0"
+  },
+  "require-dev": {},
+  "config": {
+    "preferred-install": "dist",
+    "sort-packages": true,
+    "optimize-autoloader": true
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,19 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "8bb0a2358b29066c199dfaca0f0e7c6a",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.0"
+    },
+    "platform-dev": []
+}

--- a/contrib/PHPMailer_v5.1/PHPMailerAutoload.php
+++ b/contrib/PHPMailer_v5.1/PHPMailerAutoload.php
@@ -30,20 +30,5 @@ function PHPMailerAutoload($classname)
     }
 }
 
-if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
-    //SPL autoloading was introduced in PHP 5.1.2
-    if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
-        spl_autoload_register('PHPMailerAutoload', true, true);
-    } else {
-        spl_autoload_register('PHPMailerAutoload');
-    }
-} else {
-    /**
-     * Fall back to traditional autoload for old PHP versions
-     * @param string $classname The name of the class to load
-     */
-    function __autoload($classname)
-    {
-        PHPMailerAutoload($classname);
-    }
-}
+//SPL autoloading was introduced in PHP 5.1.2
+spl_autoload_register('PHPMailerAutoload', true, true);

--- a/header.php
+++ b/header.php
@@ -47,6 +47,7 @@ if( strpos($_SERVER['PHP_SELF'], 'header.php') )
 if( !defined('IN_CODE') )
 	define('IN_CODE', 1); // A flag to tell scripts they aren't being executed by themselves
 
+require_once 'vendor/autoload.php';
 require_once('config.php');
 
 require_once('global/definitions.php');

--- a/variants/variant.php
+++ b/variants/variant.php
@@ -388,16 +388,15 @@ abstract class WDVariant {
  * [Name]Variant -> variants/[Name]/variant.php
  * [Name]Variant_[Class] -> variants/[Name]/classes/[Class].php
  */
-function __autoload($classname) {
+spl_autoload_register(function ($classname) {
+    $pos = strpos($classname, 'Variant');
+    if (empty($pos)) return;
 
-	if( !( $pos=strpos($classname,'Variant') ) || $pos==0 ) return;
+    $variantName = substr($classname, 0, $pos);
 
-	$variantName=substr($classname, 0, $pos);
+    $variantFile = $classname == $variantName . 'Variant' ?
+        l_r('variants/' . $variantName . '/variant.php') :
+        l_r('variants/' . $variantName . '/classes/' . substr($classname, ($pos + 8)) . '.php');
 
-	if( $classname==$variantName.'Variant' )
-		require_once(l_r('variants/'.$variantName.'/variant.php'));
-	else
-		require_once(l_r('variants/'.$variantName.'/classes/'.substr($classname, ($pos+8)).'.php'));
-}
-
-?>
+    require_once $variantFile;
+});


### PR DESCRIPTION
### Proposal: Add Composer for dependency management

Modern PHP apps utilize composer for dependency management to allow for external library usage, [PSR-4](https://www.php-fig.org/psr/psr-4/) standards compatibility, and built-in autoloading.

This adds composer to webDip, which only adds one step to be run during initial install (`composer install`). Note: this would need to be run whenever the code is deployed to the actual server, along with installing composer on it first.

Thoughts? This could allow webDip to benefit from a bunch of external libraries (such as templating, API generation, serialization, DB access, caching, etc).