### PR TITLE
GR Integration

### DIFF
--- a/admin/adminActionsRestricted.php
+++ b/admin/adminActionsRestricted.php
@@ -1158,7 +1158,8 @@ class adminActionsRestricted extends adminActionsSeniorMod
 		";
 	}
 
-	public function calculateGR($params) {
+	public function calculateGR($params)
+	{
 		require_once(l_r('ghostratings/calculations.php'));
 		global $DB;
 		$batch_size = (int)$params['batchSize'];

--- a/config.sample.php
+++ b/config.sample.php
@@ -126,6 +126,12 @@ class Config
 	public static $variants=array(1=>'Classic', 2=>'World', 9=>'AncMed',19=>'Modern2',20=>'Empire4');//3=>'FleetRome', 4=>'CustomStart', 5=>'BuildAnywhere');
 
 	/**
+	 * A boolean controlling whether automatic gr calculations are enabled. Set to true for auto-GR calculation and false to require manual calculations via the modtool. Note that $grCategories must exist to work.
+	 * @var boolean
+	 */
+	public static $grActive = false;
+
+	/**
 	 * An array of categories to use when calculating GhostRatings
 	 * @var array
 	 */

--- a/config.sample.php
+++ b/config.sample.php
@@ -140,7 +140,7 @@ class Config
 			"variants" => array(1,2,9,19,20,17),
 			/*pressMods sets which press type to include*/
 			"presses" => array('Regular','PublicPressOnly','NoPress','RulebookPress'),
-			/*phases sets whether you want to include live games, non-live games, or both. The cutoff is at 1 hour phase lengths*/
+			/*phases sets whether you want to include live games, non-live games, or both. The cutoff is at 1 hour phase lengths. 1 hour phases are considered non-live*/
 			"phases" => array('Live', 'Nonlive'),
 			/*scoring lets you choose what type of scoring sytems to include - only these three types are supported in the current code*/
 			"scoring" => array('Winner-takes-all','Points-per-supply-center','Sum-of-squares')

--- a/config.sample.php
+++ b/config.sample.php
@@ -126,6 +126,79 @@ class Config
 	public static $variants=array(1=>'Classic', 2=>'World', 9=>'AncMed',19=>'Modern2',20=>'Empire4');//3=>'FleetRome', 4=>'CustomStart', 5=>'BuildAnywhere');
 
 	/**
+	 * An array of categories to use when calculating GhostRatings
+	 * @var array
+	 */
+	public static $grCategories=array(
+		/* A Category ID maps to an array of settings */
+		0 => array(
+			/*gives the name of the category*/
+			"name" => "Overall",
+			/*Different scoring systems are used for 1v1 and non-1v1*/
+			"1v1" => "No",
+			/*variantMods sets which variants to include*/
+			"variants" => array(1,2,9,19,20,17),
+			/*pressMods sets which press type to include*/
+			"presses" => array('Regular','PublicPressOnly','NoPress','RulebookPress'),
+			/*phases sets whether you want to include live games, non-live games, or both. The cutoff is at 1 hour phase lengths*/
+			"phases" => array('Live', 'Nonlive'),
+			/*scoring lets you choose what type of scoring sytems to include - only these three types are supported in the current code*/
+			"scoring" => array('Winner-takes-all','Points-per-supply-center','Sum-of-squares')
+		),
+		1 => array(
+			"name" => "Gunboat",
+			"1v1" => "No",
+			"variants" => array(1,2,9,19,20,17),
+			"presses" => array('NoPress'),
+			"phases" => array('Live', 'Nonlive'),
+			"scoring" => array('Winner-takes-all','Points-per-supply-center','Sum-of-squares')
+		),
+		2 => array(
+			"name" => "Live",
+			"1v1" => "No",
+			"variants" => array(1,2,9,19,20,17),
+			"presses" => array('Regular','PublicPressOnly','NoPress','RulebookPress'),
+			"phases" => array('Live'),
+			"scoring" => array('Winner-takes-all','Points-per-supply-center','Sum-of-squares')
+		),
+		3 => array(
+			"name" => "Full Press",
+			"1v1" => "No",
+			"variants" => array(1),
+			"presses" => array('Regular'),
+			"phases" => array('Nonlive'),
+			"scoring" => array('Winner-takes-all','Sum-of-squares')
+		),
+		4 => array (
+			"name" => "1v1 Overall",
+			"1v1" => "Yes",
+			"variants" => array(15,23)
+		),
+		5 => array (
+			"name" => "FvA",
+			"1v1" => "Yes",
+			"variants" => array(15)
+		),
+		6 => array (
+			"name" => "GvI",
+			"1v1" => "Yes",
+			"variants" => array(23)
+		)
+	);
+	
+	/**
+	 * An array of modvalues to use when calculating GhostRatings. The lower the number the more weight it carries
+	 * @var array
+	 */
+	public static $grVariantMods = array(1=>1, 2=>4, 9=>2, 19=>4, 20=>4, 15=>1, 23=>1, 17=>8);
+	
+	/**
+	 * An array of modvalues to use when calculating GhostRatings. The lower the number the more weight it carries
+	 * @var array
+	 */
+	public static $grPressMods = array('Regular'=>1,'PublicPressOnly'=>2,'NoPress'=>4,'RulebookPress'=>1);
+
+	/**
 	 * The API configuration. Whether to enable it or not, and restrict it to some variants or some gameIDs.
 	 *
 	 * @var array

--- a/gamemaster/game.php
+++ b/gamemaster/game.php
@@ -1081,9 +1081,15 @@ class processGame extends Game
 		//Do GR Stuff
 		if (isset(Config::$grCategories))
 		{
-		  list($memberStatus, $SCcounts, $botGame) = $this->prepGR();
-		  $ghostRatings = new GhostRatings($this->id, $SCcounts, $memberStatus, $this->variantID, $this->pressType, $this->potType, $this->turn, "Won", $this->phaseMinutes, $this->Variant->terrIDByName["supplyCenterTarget"], $this->Variant->terrIDByName["supplyCenterCount"], $Winner->userID, $botGame, time());
-		  $ghostRatings->processGR();
+			if (isset(Config::$grActive))
+			{
+				if (Config::$grActive)
+				{
+				  list($memberStatus, $SCcounts, $botGame) = $this->prepGR();
+				  $ghostRatings = new GhostRatings($this->id, $SCcounts, $memberStatus, $this->variantID, $this->pressType, $this->potType, $this->turn, "Won", $this->phaseMinutes, $this->Variant->terrIDByName["supplyCenterTarget"], $this->Variant->terrIDByName["supplyCenterCount"], $Winner->userID, $botGame, time());
+				  $ghostRatings->processGR();
+				}
+			}
 		}
 		
 		// Then the game is set to finished
@@ -1275,9 +1281,15 @@ class processGame extends Game
 		//Do GR Stuff
 		if (isset(Config::$grCategories))
 		{
-			list($memberStatus, $SCcounts, $botGame) = $this->prepGR();
-			$ghostRatings = new GhostRatings($this->id, $SCcounts, $memberStatus, $this->variantID, $this->pressType, $this->potType, $this->turn, "Drawn", $this->phaseMinutes, $this->Variant->terrIDByName["supplyCenterTarget"], $this->Variant->terrIDByName["supplyCenterCount"], 0, $botGame, time());
-			$ghostRatings->processGR();
+			if (isset(Config::$grActive))
+			{
+				if (Config::$grActive)
+				{
+					list($memberStatus, $SCcounts, $botGame) = $this->prepGR();
+					$ghostRatings = new GhostRatings($this->id, $SCcounts, $memberStatus, $this->variantID, $this->pressType, $this->potType, $this->turn, "Drawn", $this->phaseMinutes, $this->Variant->terrIDByName["supplyCenterTarget"], $this->Variant->terrIDByName["supplyCenterCount"], 0, $botGame, time());
+					$ghostRatings->processGR();
+				}
+			}
 		}
 		
 		$this->setPhase('Finished', 'Drawn');

--- a/ghostratings/calculations.php
+++ b/ghostratings/calculations.php
@@ -44,8 +44,8 @@ defined('IN_CODE') or die('This script can not be run by itself.');
    private $pressMod;
    private $modValue;
    
-   private $k;
-   private $start;
+   private $k; //This determines how much an individual game affects a players ranking in 1v1s.
+   private $start; //This determines the starting ranking for a player in 1v1s.
    private $modMultiplier;
 
  	
@@ -66,10 +66,10 @@ defined('IN_CODE') or die('This script can not be run by itself.');
      $this->winner = $winner;
      $this->botGame = $botGame;
      $this->time = $time;
-     $this->k = 32;
-     $this->start = 100;
+     $this->k = 32; //A higher k value means players will move faster up and down in rankings.
+     $this->start = 100; //32 and 100 are arbitrary numbers used for scaling in 1v1 rankings.
      $this->pressMod = Config::$grPressMods[$this->pressType];
-     $this->modvalue = (17.5 * $this->variantMod * $this->pressMod);
+     $this->modvalue = (17.5 * $this->variantMod * $this->pressMod); //17.5 is the 'k' value for non 1v1 games and is used for scaling.
    }
      
    public function processGR()
@@ -331,16 +331,16 @@ defined('IN_CODE') or die('This script can not be run by itself.');
              }
              else
              {
-               $DB->sql_put("UPDATE wD_GhostRatingsHistory SET rating=".$newRating." WHERE userID=".$userID." AND categoryID=".$categoryID." AND monthYear=".$date);
+               $DB->sql_put("UPDATE wD_GhostRatingsHistory SET rating=".$newRating." WHERE userID=".$userID." AND categoryID=".$categoryID." AND monthYear=".$date." LIMIT 1");
              }
-             $sqlUpdate = $sqlUpdate . " WHERE categoryID=".$categoryID." AND userID=".$userID;
+             $sqlUpdate = $sqlUpdate . " WHERE categoryID=".$categoryID." AND userID=".$userID." LIMIT 1";
              $DB->sql_put($sqlUpdate);
              $DB->sql_put("INSERT INTO wD_GhostRatingsBackup(userID, categoryID, gameID, adjustment, timeFinished) VALUES(".$userID.", ".$categoryID.", ".$this->gameID.", ".$adjustment.", ".$this->time.")");
            }
          }
        }
      }
-     $DB->sql_put("UPDATE wD_Games SET grCalculated=1 WHERE id=".$this->gameID);
+     $DB->sql_put("UPDATE wD_Games SET grCalculated=1 WHERE id=".$this->gameID." LIMIT 1");
    }
  }
 ?>

--- a/ghostratings/calculations.php
+++ b/ghostratings/calculations.php
@@ -1,0 +1,346 @@
+<?php
+/*
+    Copyright (C) 2004-2010 Kestas J. Kuliukas
+
+	This file is part of webDiplomacy.
+
+    webDiplomacy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    webDiplomacy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with webDiplomacy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+defined('IN_CODE') or die('This script can not be run by itself.');
+
+/**
+ * Code that calculates and alters Ghost Ratings
+ *
+ */
+ class GhostRatings
+ {  
+   private $gameID;
+   private $SCcounts;
+   private $memberStatus;
+   private $variantID;
+   private $pressType;
+   private $potType;
+   private $gameTurns;
+   private $gameStatus;
+   private $phaseMinutes;
+   private $victorySC;
+   private $variantSC;
+   private $winner;
+   private $time;
+   
+   private $variantMod;
+   private $pressMod;
+   private $modValue;
+   
+   private $k;
+   private $start;
+   private $modMultiplier;
+
+ 	
+ 	public function __construct($gameID, $SCcounts, $memberStatus, $variantID, $pressType, $potType, $gameTurns, $gameStatus, $phaseMinutes, $victorySC, $variantSC, $winner, $botGame, $time)
+   {
+     $this->gameID = $gameID;
+     $this->SCcounts = $SCcounts;
+     $this->memberStatus = $memberStatus;
+     $this->variantID = $variantID;
+     $this->pressType = $pressType;
+     $this->potType = $potType;
+     $this->gameTurns = $gameTurns;
+     $this->gameStatus = $gameStatus;
+     $this->phaseMinutes = $phaseMinutes;
+     $this->variantMod = Config::$grVariantMods[$this->variantID];
+     $this->victorySC = $victorySC;
+     $this->variantSC = $variantSC;
+     $this->winner = $winner;
+     $this->botGame = $botGame;
+     $this->time = $time;
+     $this->k = 32;
+     $this->start = 100;
+     $this->pressMod = Config::$grPressMods[$this->pressType];
+     $this->modvalue = (17.5 * $this->variantMod * $this->pressMod);
+   }
+     
+   public function processGR()
+   {
+     global $DB;
+     //This first section checks to see if the game should be processed and iterates through each category, also making checks for whether to calculate or not
+     if ($this->gameTurns > 3 and $this->botGame <> True)
+     {
+       foreach(Config::$grCategories as $categoryID => $categoryData)
+       {
+         $calculate = True;
+         if(in_array($this->variantID,$categoryData["variants"]))
+         {
+           if ($categoryData["1v1"] <> "Yes")
+           {
+             if (!(in_array($this->pressType,$categoryData["presses"])))
+             {
+               $calculate = False;
+             }
+             else if (!(in_array($this->potType,$categoryData["scoring"])))
+             {
+               $calculate = False;
+             }
+             else
+             {
+               if ($this->phaseMinutes < 60)
+               {
+                 if (!(in_array("Live",$categoryData["phases"])))
+                 {
+                   $calculate = False;
+                 }
+               }
+               else
+               {
+                 if (!(in_array("Nonlive",$categoryData["phases"])))
+                 {
+                   $calculate = False;
+                 }
+               }
+             }
+           }
+         }
+         else
+         {
+           $calculate = False;
+         }
+         if ($calculate)
+         {
+           //First we need to grab everyones GR for this category to use in the calculations
+           $userGR = array();
+           $peakGR = array();
+           $monthYear = array();
+           $grSum = 0;
+           $first = True;
+           $date = date('my',$this->time);
+           foreach($this->SCcounts as $userID=>$scs)
+           {
+             $rating = $this->start;
+             $peakRating = $rating;
+             $userDate = $date;
+             $sqlCount = "SELECT COUNT(1) FROM wD_GhostRatings WHERE categoryID=".$categoryID." AND userID=".$userID;
+             $sql = "SELECT rating, peakRating, monthYear FROM wD_GhostRatings WHERE categoryID=".$categoryID." AND userID=".$userID;
+             $inDB = 1;
+             list($inDB) = $DB->sql_row($sqlCount);
+             if ($inDB < 1)
+             {
+               $DB->sql_put("INSERT INTO wD_GhostRatings(userID, categoryID, rating, peakrating, monthYear) VALUES(".$userID.", ".$categoryID.", ".$rating.", ".$peakRating.", ".$date.")");
+               $DB->sql_put("INSERT INTO wD_GhostRatingsHistory(userID, categoryID, monthYear, rating) VALUES(".$userID.", ".$categoryID.", ".$date.", ".$rating.")");
+             }
+             else
+             {
+               list($rating, $peakRating, $userDate) = $DB->sql_row($sql);
+             }
+             $userGR[$userID] = $rating;
+             $peakGR[$userID] = $peakRating;
+             $monthYear[$userID] = $userDate;
+             $grSum += $rating;
+           }
+           $grAdjustment = array();
+           //Next we divide up based on the scoring type
+           switch($this->potType)
+           {
+             case "Points-per-supply-center":
+               $expectedResult = array();
+               $actualResult = array();
+               $firstplace = array();
+               $secondplace = array();
+               $secondplaceSum = 0;
+               $drawNum = 0;
+               foreach($userGR as $userID => $rating)
+               {
+                 $firstplace[$userID] = $rating / $grSum;
+                 $secondplace[$userID] = 0;
+                 foreach($userGR as $nID => $nRating)
+                 {
+                   if ($userID <> $nID)
+                   {
+                     $secondplace[$userID] = $secondplace[$userID] + (($nRating*$rating)/(($grSum*$grSum)-($grSum*$nRating)));
+                   }
+                 }
+                 $secondplace[$userID] = $secondplace[$userID] * (1 - $firstplace[$userID]);
+                 $secondplaceSum += $secondplace[$userID];
+                 if ($this->memberStatus[$userID] == 'Drawn')
+                 {
+                   $drawNum += 1;
+                 }
+               }
+               foreach ($userGR as $userID => $rating)
+               {
+                 $expectedResult[$userID] = (($this->victorySC * $firstplace[$userID]) + ((($this->variantSC - $this->victorySC) * $secondplace[$userID]) / $secondplaceSum)) / $this->variantSC;
+                 if ($this->gameStatus == "Drawn")
+                 {
+                   if($this->memberStatus[$userID] == 'Drawn')
+                   {
+                     $actualResult[$userID] = 1/$drawNum;
+                   }
+                   else
+                   {
+                     $actualResult[$userID] = 0;
+                   }
+                 }
+                 else
+                 {
+                   $actualResult[$userID] = $this->SCcounts[$userID] / (float) $this->variantSC;
+                 }
+                 $grAdjustment[$userID] = (($grSum / $this->modvalue) * ($actualResult[$userID]-$expectedResult[$userID]));
+               }
+               break;
+             case "Winner-takes-all":
+               $expectedResult = array();
+               $actualResult = array();
+               $drawNum = 0;
+               foreach($userGR as $userID => $rating)
+               {
+                 if ($this->memberStatus[$userID] == 'Drawn')
+                 {
+                   $drawNum += 1;
+                 }
+               }
+               foreach ($userGR as $userID => $rating)
+               {
+                 $expectedResult[$userID] = $rating / $grSum;
+                 if ($this->gameStatus == "Drawn")
+                 {
+                   if($this->memberStatus[$userID] == 'Drawn')
+                   {
+                     $actualResult[$userID] = 1/$drawNum;
+                   }
+                   else
+                   {
+                     $actualResult[$userID] = 0;
+                   }
+                 }
+                 else
+                 {
+                   if($userID == $this->winner)
+                   {
+                     $actualResult[$userID] = 1;
+                   }
+                   else
+                   {
+                     $actualResult[$userID] = 0;
+                   }
+                 }
+                 $grAdjustment[$userID] = (($grSum / $this->modvalue) * ($actualResult[$userID]-$expectedResult[$userID]));
+               }
+               
+               break;
+             case "Sum-of-squares":
+               $expectedResult = array();
+               $actualResult = array();
+               $expectedSquare = array();
+               $actualSquare = array();
+               $expectedSum = 0;
+               $actualSum = 0;
+               $drawNum = 0;
+               foreach($userGR as $userID => $rating)
+               {
+                 if ($this->memberStatus[$userID] == 'Drawn')
+                 {
+                   $drawNum += 1;
+                 }
+                   $actualSquare[$userID] = $this->SCcounts[$userID] * $this->SCcounts[$userID];
+                   $expectedSquare[$userID] = $rating * $rating;
+                   $actualSum += $actualSquare[$userID];
+                   $expectedSum += $expectedSquare[$userID];
+               }
+               foreach ($userGR as $userID => $rating)
+               {
+                 $expectedResult[$userID] = $expectedSquare[$userID] / $expectedSum;
+                 if ($this->gameStatus == "Drawn" && $this->memberStatus[$userID] == 'Drawn')
+                 {
+                   $actualResult[$userID] = $actualSquare[$userID] /$actualSum;
+                 }
+                 else
+                 {
+                   if($userID == $this->winner)
+                   {
+                     $actualResult[$userID] = 1;
+                   }
+                   else
+                   {
+                     $actualResult[$userID] = 0;
+                   }
+                 }
+                 $grAdjustment[$userID] = (($grSum / $this->modvalue) * ($actualResult[$userID]-$expectedResult[$userID]));
+               }
+               break;
+             //In this case we assume that all 1v1 games are unranked, and the previous code excludes unranked non-1v1 games from being calculated, so this is the 1v1 calculation 
+             case "Unranked":
+               $first = True;
+               $r1 = 0;
+               $r2 = 0;
+               $id1 = 0;
+               $id2 = 0;
+               $result = 0;
+               foreach ($userGR as $userID => $rating)
+               {
+                 if($first)
+                 {
+                   $r1 = $rating;
+                   $id1 = $userID;
+                   $first = False;
+                 }
+                 else
+                 {
+                   $r2 = $rating;
+                   $id2 = $userID;
+                 }
+               }
+               if ($this->gameStatus == "Drawn")
+               {
+                 $result = 0.5;
+               }
+               else if ($this->winner == $id1)
+               {
+                 $result = 1;
+               }
+               $R1 = pow(10,($r1/400));
+               $R2 = pow(10,($r2/400));
+               $E1 = $R1 / ($R1 + $R2);
+               $E2 = $R2 / ($R1 + $R2);
+               $grAdjustment[$id1] = $this->k * ($result - $E1);
+               $grAdjustment[$id2] = $this->k * (1 - $result - $E2);
+               break;
+           }
+           foreach ($grAdjustment as $userID=>$adjustment)
+           {
+             $newRating = $userGR[$userID] + $adjustment;
+             $sqlUpdate = "UPDATE wD_GhostRatings SET rating=".$newRating;
+             if ($newRating > $peakGR[$userID])
+             {
+               $sqlUpdate = $sqlUpdate . ", peakRating=".$newRating;
+             }
+             if ($date <> $monthYear[$userID])
+             {
+               $sqlUpdate = $sqlUpdate. ", monthYear=".$date;
+               $DB->sql_put("INSERT INTO wD_GhostRatingsHistory(userID, categoryID, monthYear, rating) VALUES(".$userID.", ".$categoryID.", ".$date.", ".$newRating.")");
+             }
+             else
+             {
+               $DB->sql_put("UPDATE wD_GhostRatingsHistory SET rating=".$newRating." WHERE userID=".$userID." AND categoryID=".$categoryID." AND monthYear=".$date);
+             }
+             $sqlUpdate = $sqlUpdate . " WHERE categoryID=".$categoryID." AND userID=".$userID;
+             $DB->sql_put($sqlUpdate);
+             $DB->sql_put("INSERT INTO wD_GhostRatingsBackup(userID, categoryID, gameID, adjustment, timeFinished) VALUES(".$userID.", ".$categoryID.", ".$this->gameID.", ".$adjustment.", ".$this->time.")");
+           }
+         }
+       }
+     }
+     $DB->sql_put("UPDATE wD_Games SET grCalculated=1 WHERE id=".$this->gameID);
+   }
+ }
+?>

--- a/global/definitions.php
+++ b/global/definitions.php
@@ -24,7 +24,7 @@
 
 defined('IN_CODE') or die('This script can not be run by itself.');
 
-define("VERSION", 165);
+define("VERSION", 166);
 
 
 // Some integer values which are named for clarity.

--- a/install/1.65-1.66/readme.txt
+++ b/install/1.65-1.66/readme.txt
@@ -1,0 +1,9 @@
+Changelog
+---------
+* Added table `wD_GhostRatings`, `wD_GhostRatingsHistory`, and `wD_GhostRatingsBackup` to store GR data
+* wD_GhostRatings is to track current GR, wD_GhostRatingsHistory tracks month to month GR, and wD_GhostRatingsBackup tracks each games adjustment
+* Added a column to `wD_Games` to track which games have had their GR calculated
+
+Updating
+--------
+-

--- a/install/1.65-1.66/update.sql
+++ b/install/1.65-1.66/update.sql
@@ -1,0 +1,28 @@
+UPDATE `wD_Misc` SET `value` = '166' WHERE `name` = 'Version';
+
+CREATE TABLE `wD_GhostRatings` (
+`userID` mediumint(8) unsigned NOT NULL,
+`categoryID` mediumint(8) unsigned NOT NULL,
+`rating` FLOAT,
+`peakRating` FLOAT,
+`monthYear` smallint(4) unsigned NOT NULL,
+INDEX ( `userID` )
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+CREATE TABLE `wD_GhostRatingsHistory` (
+`userID` mediumint(8) unsigned NOT NULL,
+`categoryID` mediumint(8) unsigned NOT NULL,
+`monthYear` smallint(4) unsigned NOT NULL,
+`rating` FLOAT,
+INDEX ( `userID` )
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+CREATE TABLE `wD_GhostRatingsBackup` (
+  `userID` mediumint(8) unsigned NOT NULL,
+  `categoryID` mediumint(8) unsigned NOT NULL,
+  `gameID` mediumint(8) unsigned NOT NULL,
+  `adjustment` FLOAT,
+  `timeFinished` int(10) unsigned NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+ALTER TABLE `wD_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;

--- a/install/1.65-1.66/update.sql
+++ b/install/1.65-1.66/update.sql
@@ -6,7 +6,9 @@ CREATE TABLE `wD_GhostRatings` (
 `rating` FLOAT,
 `peakRating` FLOAT,
 `monthYear` smallint(4) unsigned NOT NULL,
-INDEX ( `userID` )
+INDEX ( `userID` ),
+INDEX ( `categoryID` ),
+INDEX ( `monthYear` )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 CREATE TABLE `wD_GhostRatingsHistory` (
@@ -14,15 +16,21 @@ CREATE TABLE `wD_GhostRatingsHistory` (
 `categoryID` mediumint(8) unsigned NOT NULL,
 `monthYear` smallint(4) unsigned NOT NULL,
 `rating` FLOAT,
-INDEX ( `userID` )
+INDEX ( `userID` ),
+INDEX ( `categoryID` ),
+INDEX ( `monthYear` )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 CREATE TABLE `wD_GhostRatingsBackup` (
-  `userID` mediumint(8) unsigned NOT NULL,
-  `categoryID` mediumint(8) unsigned NOT NULL,
-  `gameID` mediumint(8) unsigned NOT NULL,
-  `adjustment` FLOAT,
-  `timeFinished` int(10) unsigned NOT NULL
+`userID` mediumint(8) unsigned NOT NULL,
+`categoryID` mediumint(8) unsigned NOT NULL,
+`gameID` mediumint(8) unsigned NOT NULL,
+`adjustment` FLOAT,
+`timeFinished` int(10) unsigned NOT NULL,
+INDEX ( `userID`),
+INDEX ( `categoryID` )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 ALTER TABLE `wD_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;
+
+ALTER TABLE `wD_Backup_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;

--- a/install/1.65-1.66/update.sql
+++ b/install/1.65-1.66/update.sql
@@ -31,6 +31,10 @@ INDEX ( `userID`),
 INDEX ( `categoryID` )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-ALTER TABLE `wD_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;
+ALTER TABLE `wD_Games`
+ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0,
+ADD INDEX ( `grCalculated`);
 
-ALTER TABLE `wD_Backup_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;
+ALTER TABLE `wD_Backup_Games`
+ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0,
+ADD INDEX (`grCalculated`);

--- a/install/FullInstall/fullInstall.sql
+++ b/install/FullInstall/fullInstall.sql
@@ -970,8 +970,12 @@ INDEX ( `userID`),
 INDEX ( `categoryID` )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
-ALTER TABLE `wD_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;
+ALTER TABLE `wD_Games`
+ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0,
+ADD INDEX ( `grCalculated`);
 
-ALTER TABLE `wD_Backup_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;
+ALTER TABLE `wD_Backup_Games`
+ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0,
+ADD INDEX (`grCalculated`);
 
 UPDATE `wD_Misc` SET `value` = '166' WHERE `name` = 'Version';

--- a/install/FullInstall/fullInstall.sql
+++ b/install/FullInstall/fullInstall.sql
@@ -945,7 +945,9 @@ CREATE TABLE `wD_GhostRatings` (
 `rating` FLOAT,
 `peakRating` FLOAT,
 `monthYear` smallint(4) unsigned NOT NULL,
-INDEX ( `userID` )
+INDEX ( `userID` ),
+INDEX ( `categoryID` ),
+INDEX ( `monthYear` )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 CREATE TABLE `wD_GhostRatingsHistory` (
@@ -953,17 +955,23 @@ CREATE TABLE `wD_GhostRatingsHistory` (
 `categoryID` mediumint(8) unsigned NOT NULL,
 `monthYear` smallint(4) unsigned NOT NULL,
 `rating` FLOAT,
-INDEX ( `userID` )
+INDEX ( `userID` ),
+INDEX ( `categoryID` ),
+INDEX ( `monthYear` )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 CREATE TABLE `wD_GhostRatingsBackup` (
-  `userID` mediumint(8) unsigned NOT NULL,
-  `categoryID` mediumint(8) unsigned NOT NULL,
-  `gameID` mediumint(8) unsigned NOT NULL,
-  `adjustment` FLOAT,
-  `timeFinished` int(10) unsigned NOT NULL
+`userID` mediumint(8) unsigned NOT NULL,
+`categoryID` mediumint(8) unsigned NOT NULL,
+`gameID` mediumint(8) unsigned NOT NULL,
+`adjustment` FLOAT,
+`timeFinished` int(10) unsigned NOT NULL,
+INDEX ( `userID`),
+INDEX ( `categoryID` )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 ALTER TABLE `wD_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;
+
+ALTER TABLE `wD_Backup_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;
 
 UPDATE `wD_Misc` SET `value` = '166' WHERE `name` = 'Version';

--- a/install/FullInstall/fullInstall.sql
+++ b/install/FullInstall/fullInstall.sql
@@ -931,8 +931,6 @@ CREATE TABLE `wD_EmailHistory` (
   `changedBy` varchar(30) NOT NULL
 )
 
-UPDATE `wD_Misc` SET `value` = '164' WHERE `name` = 'Version';
-
 ALTER TABLE `wD_Users`
 CHANGE `type` `type` SET(
 	'Banned', 'Guest', 'System', 'User', 'Moderator',
@@ -941,4 +939,31 @@ CHANGE `type` `type` SET(
 	'DonatorAdamantium', 'DonatorService', 'DonatorOwner', 'Bot', 'SeniorMod'
 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT 'User';
 
-UPDATE `wD_Misc` SET `value` = '165' WHERE `name` = 'Version';
+CREATE TABLE `wD_GhostRatings` (
+`userID` mediumint(8) unsigned NOT NULL,
+`categoryID` mediumint(8) unsigned NOT NULL,
+`rating` FLOAT,
+`peakRating` FLOAT,
+`monthYear` smallint(4) unsigned NOT NULL,
+INDEX ( `userID` )
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+CREATE TABLE `wD_GhostRatingsHistory` (
+`userID` mediumint(8) unsigned NOT NULL,
+`categoryID` mediumint(8) unsigned NOT NULL,
+`monthYear` smallint(4) unsigned NOT NULL,
+`rating` FLOAT,
+INDEX ( `userID` )
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+CREATE TABLE `wD_GhostRatingsBackup` (
+  `userID` mediumint(8) unsigned NOT NULL,
+  `categoryID` mediumint(8) unsigned NOT NULL,
+  `gameID` mediumint(8) unsigned NOT NULL,
+  `adjustment` FLOAT,
+  `timeFinished` int(10) unsigned NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+ALTER TABLE `wD_Games` ADD COLUMN `grCalculated` INT NOT NULL DEFAULT 0;
+
+UPDATE `wD_Misc` SET `value` = '166' WHERE `name` = 'Version';


### PR DESCRIPTION
This code attempts to integrate Ghost Ratings into webDiplomacy. Includes code that takes in game data and calculates GR adjustments. Integrates this code so that when games finish, GR is automatically adjusted. Provides an admin tool to backfill GR in batches. Has multiple table in the database to store GR historical data. This includes a game by game, user by user accounting of each GR adjustment (very detailed), as well as a month by month accounting of each user's GR (big picture). The config file has been adjusted to allow for customization of these GR calculations. You can create your own categories and filter by variant ID, press type, phase length, scoring type, etc.

As this is a large change, thorough testing and reviewing is needed. I have conducted a lot of testing on the actual math side of things and I am confident that the GR scoring is correct (more correct than the old scripts even), now it is mostly just making sure that this isn't breaking games and covers each of the unique scenarios correctly.