### PR TITLE
GIF Feature

### DIFF
--- a/board.php
+++ b/board.php
@@ -121,6 +121,7 @@ if ( isset($_REQUEST['viewArchive']) )
 		case 'Messages': require_once(l_r('board/info/messages.php')); break;
 		case 'Graph': require_once(l_r('board/info/graph.php')); break;
 		case 'Maps': require_once(l_r('board/info/maps.php')); break;
+		case 'Gif': require_once(l_r('board/info/gif.php')); break;
 		case 'Reports':
 			require_once(l_r('lib/modnotes.php'));
 			libModNotes::checkDeleteNote();

--- a/board/info/gif.php
+++ b/board/info/gif.php
@@ -1,0 +1,50 @@
+<?php
+/*
+    Copyright (C) 2004-2010 Kestas J. Kuliukas
+
+	This file is part of webDiplomacy.
+
+    webDiplomacy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    webDiplomacy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with webDiplomacy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+defined('IN_CODE') or die('This script can not be run by itself.');
+
+/**
+ * Return a gif animation of the whole game
+ *
+ * @package Board
+ */
+
+require_once('board/info/gif/animate.php');
+
+if ( $Game->phase != 'Finished' )
+{
+	libHTML::error(l_t("The game you selected is still ongoing. Animations are only available for finished games."));
+}
+
+print '<h3>'.l_t('GIF Animation').'</h3>';
+
+$animation_url = 'cache/games/0/'.$Game->id.'/animation.gif';
+
+if ( ! file_exists($animation_url) )
+{
+	$Game->create_webDip_animation();
+}
+
+print '<p style="text-align:center">
+		<img src="'.$animation_url.'" title="'.l_t('Animation').'" />
+		<br /><br /><br />
+		</p>';
+
+?>

--- a/board/info/gif/animate.php
+++ b/board/info/gif/animate.php
@@ -1,0 +1,294 @@
+<?php
+/*
+    Copyright (C) 2004-2010 Kestas J. Kuliukas
+
+	This file is part of webDiplomacy.
+
+    webDiplomacy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    webDiplomacy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with webDiplomacy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+	This file is a stripped version of the AnimGif class released under GNU Public License 
+		@ https://github.com/lunakid/AnimGif.
+	The AnimGif class is a fork of Clément Guillemain's GifCreator class released under GNU Public License
+		@ https://github.com/Sybio/GifCreator.
+		
+	@ authors Sybio (Clément Guillemain / @Sybio01) and lunakid (@GitHub, @Gmail, @SO etc.)
+	@ license http://opensource.org/licenses/gpl-license.php GNU Public License
+	@ copyright Clément Guillemain and Szabolcs Szász
+
+	The class has been stripped to only include the code necessary for the GIF feature on webDiplomacy.
+ */
+ 
+defined('IN_CODE') or die('This script can not be run by itself.');
+
+class AnimGif
+{
+
+	/**
+	* @var string: The generated (binary) image
+	*/
+	private $gif;
+
+	/**
+	* @var boolean: Has an image (frame) been added already?
+	*/
+	private $imgBuilt;
+
+	/**
+	* @var array or string: Frame sources like filenames, URLs, bin. data, or a folder name
+	*/
+	private $frameSources;
+
+	/**
+	* @var integer: Gif loop count
+	*/
+	private $loop;
+
+	/**
+	* @var integer: Gif frame disposal method
+	*/
+	private $dis;
+
+	/**
+	* @var integer: Gif transparent color index
+	*/
+	private $transparent_color;
+ 
+	// Methods
+	// ===================================================================================
+    
+	public function __construct()
+	{
+		$this->reset();
+	}
+
+	/**
+	 * Create animated GIF from source images
+	 * 
+	 * @param array $frames The source iamges: can be a local dir path, or an array  
+	 *                      of file paths, resource image variables, binary data or image URLs.
+	 * @param array|number $durations The duration (in 1/100s) of the individual frames, 
+	 *                      or a single integer for each one.
+	 * @return string The resulting GIF binary data.
+	 */
+	public function create($frames, $durations)
+	{
+		// Set standard values
+		$this->loop = 0;	// loop indefinitely
+		$this->dis  = 2;	// "reset to bgnd." (http://www.matthewflickinger.com/lab/whatsinagif/animation_and_transparency.asp)
+
+		assert(is_array($frames));
+
+		$i = 0;
+		foreach ($frames as $frame) {
+
+			$bin = file_get_contents($frame); 
+			$resourceImg = imagecreatefromstring($bin);
+
+			ob_start();
+			imagegif($resourceImg);
+			$this->frameSources[] = ob_get_contents();
+			ob_end_clean();
+
+			if ($i == 0)
+				$this->transparent_color = imagecolortransparent($resourceImg);
+
+			for ($j = (13 + 3 * (2 << (ord($this->frameSources[$i] { 10 }) & 0x07))), $k = true; $k; $j++) 
+			{
+				switch ($this->frameSources[$i] { $j }) 
+				{			
+					case ';':
+		    				$k = false;
+						break;
+				}
+			}
+
+			unset($resourceImg);
+			++$i;
+		}//foreach
+
+		$this->gifAddHeader();
+
+		for ($i = 0; $i < count($this->frameSources); $i++)
+			$this->addGifFrames($i, $durations[$i]);
+
+		$this->gifAddFooter();
+		
+		return $this;
+	}
+    
+	/**
+	 * Save the resulting GIF to a file.
+	 * 
+	 * @param $filename String Target file path
+	 * 
+	 * @return that of file_put_contents($filename)
+	 */
+	public function save($filename)
+	{
+		return file_put_contents($filename, $this->gif);
+	}
+    
+	/**
+	 * Clean-up the current object (also used by the ctor.)
+	 */
+	public function reset()
+	{
+		$this->frameSources = null;
+		$this->gif = 'GIF89a'; // the GIF header
+		$this->imgBuilt = false;
+		$this->loop = 0;
+		$this->dis = 2;
+		$this->transparent_color = -1;
+	}
+	    
+	// Internals
+	// ===================================================================================
+
+	/**
+	 * Assemble the GIF header
+	 */
+	protected function gifAddHeader()
+	{
+		$cmap = 0;
+
+		if (ord($this->frameSources[0] { 10 }) & 0x80) {
+		  
+			$cmap = 3 * (2 << (ord($this->frameSources[0] { 10 }) & 0x07));
+
+			$this->gif .= substr($this->frameSources[0], 6, 7);
+			$this->gif .= substr($this->frameSources[0], 13, $cmap);
+			if ($this->loop !== 1) // Only add the looping extension if really looping
+				$this->gif .= "!\xFF\x0BNETSCAPE2.0\x03\x01".word2bin($this->loop==0?0:$this->loop-1)."\x0";
+		}
+	}
+    
+	/**
+	 * Add frame to the GIF data
+	 * 
+	 * @param integer $i: index of frame source
+	 * @param integer $d: delay time (frame display duration)
+	 */
+	protected function addGifFrames($i, $d)
+	{
+		$Locals_str = 13 + 3 * (2 << (ord($this->frameSources[ $i ] { 10 }) & 0x07));
+
+		$Locals_end = strlen($this->frameSources[$i]) - $Locals_str - 1;
+		$Locals_tmp = substr($this->frameSources[$i], $Locals_str, $Locals_end);
+
+		$Global_len = 2 << (ord($this->frameSources[0 ] { 10 }) & 0x07);
+		$Locals_len = 2 << (ord($this->frameSources[$i] { 10 }) & 0x07);
+
+		$Global_rgb = substr($this->frameSources[ 0], 13, 3 * (2 << (ord($this->frameSources[ 0] { 10 }) & 0x07)));
+		$Locals_rgb = substr($this->frameSources[$i], 13, 3 * (2 << (ord($this->frameSources[$i] { 10 }) & 0x07)));
+
+		$Locals_ext = "!\xF9\x04" . chr(($this->dis << 2) + 0) . word2bin($d) . "\x0\x0";
+        
+		switch ($Locals_tmp { 0 }) {
+		  
+			case '!':
+            
+				$Locals_img = substr($Locals_tmp, 8, 10);
+				$Locals_tmp = substr($Locals_tmp, 18, strlen($Locals_tmp) - 18);
+                                
+				break;
+                
+			case ',':
+            
+				$Locals_img = substr($Locals_tmp, 0, 10);
+				$Locals_tmp = substr($Locals_tmp, 10, strlen($Locals_tmp) - 10);
+                                
+				break;
+		}
+        
+		if (ord($this->frameSources[$i] { 10 }) & 0x80 && $this->imgBuilt) {
+		  
+			if ($Global_len == $Locals_len) {
+			 
+				if ($this->gifBlockCompare($Global_rgb, $Locals_rgb, $Global_len)) {
+				    
+					$this->gif .= $Locals_ext.$Locals_img.$Locals_tmp;
+                    
+				} else {
+				    
+					$byte = ord($Locals_img { 9 });
+					$byte |= 0x80;
+					$byte &= 0xF8;
+					$byte |= (ord($this->frameSources[0] { 10 }) & 0x07);
+					$Locals_img { 9 } = chr($byte);
+					$this->gif .= $Locals_ext.$Locals_img.$Locals_rgb.$Locals_tmp;
+				}
+                
+			} else {
+			 
+				$byte = ord($Locals_img { 9 });
+				$byte |= 0x80;
+				$byte &= 0xF8;
+				$byte |= (ord($this->frameSources[$i] { 10 }) & 0x07);
+				$Locals_img { 9 } = chr($byte);
+				$this->gif .= $Locals_ext.$Locals_img.$Locals_rgb.$Locals_tmp;
+			}
+            
+		} else {
+			$this->gif .= $Locals_ext.$Locals_img.$Locals_tmp;
+		}
+        
+		$this->imgBuilt = true;
+	}
+    
+	/**
+	 * Add the gif string footer char
+	 */
+	protected function gifAddFooter()
+	{
+		$this->gif .= ';';
+	}
+    
+	/**
+	 * Compare two blocks and return 1 if they are equal, 0 if differ.
+	 * 
+	 * @param string $globalBlock
+	 * @param string $localBlock
+	 * @param integer $length
+	 * 
+	 * @return integer
+	 */
+	protected function gifBlockCompare($globalBlock, $localBlock, $length)
+	{
+		for ($i = 0; $i < $length; $i++) {
+		  
+			if ($globalBlock [ 3 * $i + 0 ] != $localBlock [ 3 * $i + 0 ] ||
+			    $globalBlock [ 3 * $i + 1 ] != $localBlock [ 3 * $i + 1 ] ||
+			    $globalBlock [ 3 * $i + 2 ] != $localBlock [ 3 * $i + 2 ]) {
+				
+				return 0;
+			}
+		}
+
+		return 1;
+	}
+}
+
+/**
+ * Convert an integer to 2-byte little-endian binary data
+ * 
+ * @param integer $word Number to encode
+ * 
+ * @return string of 2 bytes representing @word as binary data
+ */
+function word2bin($word)
+{
+	return (chr($word & 0xFF).chr(($word >> 8) & 0xFF));
+}

--- a/gamepanel/game.php
+++ b/gamepanel/game.php
@@ -426,10 +426,17 @@ class panelGame extends Game
 	 */
 	function archiveBar()
 	{
+	    $gifLink = '';
+	    
+	    if ($this->phase == 'Finished' )
+	    {
+	    	$gifLink = ' - <a href="board.php?gameID='.$this->id.'&amp;viewArchive=Gif">'.l_t('GIF').'</a>';
+	    }
+	    
 		return '<strong>'.l_t('Archive:').'</strong> '.
 			'<a href="board.php?gameID='.$this->id.'&amp;viewArchive=Orders">'.l_t('Orders').'</a>
 			- <a href="board.php?gameID='.$this->id.'&amp;viewArchive=Maps">'.l_t('Maps').'</a>
-			- <a href="board.php?gameID='.$this->id.'&amp;viewArchive=Messages">'.l_t('Messages').'</a>';
+			- <a href="board.php?gameID='.$this->id.'&amp;viewArchive=Messages">'.l_t('Messages').'</a>'.$gifLink;
 //			- <a href="board.php?gameID='.$this->id.'&amp;viewArchive=Reports">Reports</a>';
 	}
 

--- a/objects/game.php
+++ b/objects/game.php
@@ -647,6 +647,64 @@ class Game
     {
         return $this->name;
     }
+    
+    /**
+ 	* Create a webDip animation for stored .map files
+ 	* 
+	* stores animation.gif in game cache folder
+	*/
+	function create_webDip_animation()
+	{
+
+		// Set the parameter for delays between frames of the gif file in 1/100 s.
+		// It would be nice if the users could set this parameter themselves,
+		// but that would lead to a large number of gif files in the cache folder.
+		$delay = 80;
+
+		// Only allow to make an animation if at least one turn was played.
+		if ( $this->turn == 0 )
+		{
+			return 	libHTML::error(l_t("Can not make an animation since the game ended on the first term."));
+		}
+
+		$folder = "cache/games/0/".$this->id."/";
+		$files_in_folder = scandir($folder);
+
+		function drop_suffix ($string)
+		{
+			return (int)substr($string, 0, -10);
+		}
+
+		$frames = array();
+		$durations = array();
+		foreach ($files_in_folder as $file)
+		{
+			if ( (strpos($file, "small.map") !== false) and (is_numeric(drop_suffix ($file))))
+			{
+				array_push($frames, drop_suffix($file));
+				array_push($durations, $delay);
+			}
+		}
+		
+		sort($frames);
+		
+		// Check that all the map files are in the cache.
+		if ( $frames != range(0, $this->turn) )
+		{
+			return 	libHTML::error(l_t("Some maps are missing in the cache. Try loading the map archive before making the animation."));	
+		}
+
+		// Modify $frames to contain full file paths.
+		$frames = array_map(function ($s) {return "cache/games/0/".$this->id."/".$s."-small.map";}, $frames);
+		// Modify $durations to make the last frame longer.
+		$durations[$this->turn] = 2*$delay;
+
+		$anim = new AnimGif();
+		$anim->create($frames, $durations);
+		$anim->save($folder.'animation.gif');
+
+	}
+
 }
 
 


### PR DESCRIPTION
Adds the feature to create a GIF-file from the maps from a finished game.

The link to create a GIF-file appears in the Archive bar on the game page. To avoid creation of a large number of GIF-files, the feature is only available for finished games, and the user is not allowed to modify the parameters of the GIF.

- Main code to create the GIF file is a stripped version of the AnimGif class from https://github.com/lunakid/AnimGif, see board/info/gif/animate.php
- The class Game now includes a method create_webDip_animation()
- Added file board/info/gif.php which displays the animation
- board.php and gamepanel has been adjusted accordingly

Possible issues:
The AnimGif class requires the GD extension. Works well in my dev - but not obvious it is available on the server.

Remarks:
The map file "-1-small.map", which shows the starting positions in the game, is deleted from the cache folder once the game is finished, and it is therefor not included in the animation. I believe the animation would be nicer if also this map is included, but that requires that we store copies of maps with starting positions for all variants (including inactive variants) in a separate folder.
