### PR TITLE
Change default user/game RR to 50

### DIFF
--- a/gamecreate.php
+++ b/gamecreate.php
@@ -247,12 +247,12 @@ if( isset($_REQUEST['newGame']) and is_array($_REQUEST['newGame']) )
 if ($User->reliabilityRating < 100)
 {
 	$maxRR = max(0, (floor($User->reliabilityRating - 1)));
-	$defaultRR = min(80,$maxRR);
+	$defaultRR = min(50,$maxRR);
 }
 else
 {
 	$maxRR = 100;
-	$defaultRR = 80;
+	$defaultRR = 50;
 }
 
 if ( $User->points >= 5 ) { $defaultPoints = 5; }

--- a/install/1.66-1.67/readme.txt
+++ b/install/1.66-1.67/readme.txt
@@ -1,0 +1,3 @@
+Changelog
+---------
+* Setting default user reliability rating to 50

--- a/install/1.66-1.67/update.sql
+++ b/install/1.66-1.67/update.sql
@@ -1,0 +1,3 @@
+UPDATE `wD_Misc` SET `value` = '167' WHERE `name` = 'Version';
+
+ALTER TABLE `wD_Users` ALTER `reliabilityRating` SET DEFAULT 50;

--- a/install/FullInstall/fullInstall.sql
+++ b/install/FullInstall/fullInstall.sql
@@ -669,7 +669,7 @@ ALTER TABLE `wD_Users` ADD COLUMN `cdCount` mediumint(8) unsigned NOT NULL DEFAU
   ADD COLUMN `cdTakenCount` mediumint(8) unsigned NOT NULL DEFAULT '0',
   ADD COLUMN `phaseCount` int(10) unsigned NOT NULL DEFAULT '0',
   ADD COLUMN `gameCount` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  ADD COLUMN `reliabilityRating` double NOT NULL DEFAULT '1',
+  ADD COLUMN `reliabilityRating` double NOT NULL DEFAULT '50',
   ADD COLUMN `deletedCDs` int(11) DEFAULT '0';
 
 CREATE TABLE IF NOT EXISTS `wD_NMRs` (


### PR DESCRIPTION
• Reduces default reliability rating on game creation form to 50
• Assigns new users a default reliability rating of 50 so they can play default RR games