### PR TITLE
Change Variant options to Variant fullName

### DIFF
--- a/locales/English/gamecreate.php
+++ b/locales/English/gamecreate.php
@@ -224,8 +224,8 @@ defined('IN_CODE') or die('This script can not be run by itself.');
 					if($variantID != 57)
 					{
 						$Variant = libVariant::loadFromVariantName($variantName);
-						if($first) { print '<option name="newGame[variantID]" selected value="'.$variantID.'">'.$variantName.'</option>'; }
-						else { print '<option name="newGame[variantID]" value="'.$variantID.'">'.$variantName.'</option>'; }			
+						if($first) { print '<option name="newGame[variantID]" selected value="'.$variantID.'">'.$Variant->fullName.'</option>'; }
+						else { print '<option name="newGame[variantID]" value="'.$variantID.'">'.$Variant->fullName.'</option>'; }			
 						$first=false;
 					}
 				}


### PR DESCRIPTION
Rather than using variants' short names on the gamecreate.php page, this changes it to use the long name instead. 

Tested on my local dev server with no issues.