### PR TITLE
indicate islands' inaccessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 Diplomacy is a popular turn based strategy game in which you battle to control Europe; to win you must be diplomatic and strategic.
+
  
 webDiplomacy lets you play Diplomacy online.
 


### PR DESCRIPTION
Switzerland is impassable and therefore solid black on the map, which is clear and unambiguous. However, Iceland, Ireland, Corsica, Sardinia, Sicily, Crete, Cyprus, and other islands are inaccessible too, yet they aren't indicated as such. Crete and Sardinia are always in the neutral colour, whereas the rest are considered part of the nearest coastal area and change colour accordingly. The current situation is:
* inconsistent: why treat Switzerland, Sardinia, and Crete differently?
* incorrect: Corsica has been French since 1768, not Italian; Iceland was Danish, never British; and Cyprus was a British protectorate since 1878.
* distracting: people look at the map to see what has changed; Iceland changing colour whenever a fleet enters Clyde does not help.

This pull requests proposes treating Switzerland and all islands exactly the same, by using a very dark grey (rgb = (32, 32, 32) or #202020), to indicate units can't move there, and no longer have them change colour, regardless what happens in nearby coastal areas.

This is how it would look at game start:
![start_new](https://user-images.githubusercontent.com/21634324/118016332-90ed6080-b355-11eb-95e1-07fa2f5819c9.png)

For comparison:
webdiplomacy.net:
![webdiplomacy](https://user-images.githubusercontent.com/21634324/118016389-9ea2e600-b355-11eb-8605-9fe601a4e9fc.png)
playdiplomacy.com:
![playdiplomacy](https://user-images.githubusercontent.com/21634324/118016405-a2cf0380-b355-11eb-9df1-f1d26d91a044.png)
backstabbr.com:
![backstabbr](https://user-images.githubusercontent.com/21634324/118016422-a793b780-b355-11eb-8ef6-767dc5c1cfee.png)

