### PR TITLE
less unnecessary and excessive capitalization

### DIFF
--- a/botgamecreate.php
+++ b/botgamecreate.php
@@ -149,7 +149,7 @@ print '<div class="content-bare content-board-header content-title-header">
 	<div class="pageDescription">Start a new game of Diplomacy against bots.</div>
 </div>
 <div class="content content-follow-on">
-	<p><a href="gamecreate.php">Play A Game Against Humans</a></p>
+	<p><a href="gamecreate.php">Play a game against humans</a></p>
 	<div class = "gameCreateShow">
 	<p>All games against bots are unranked, with 3 day phases and 4 excused missed turns. However, anytime you ready up your orders, the game will immediately move to the next phase.</p>
 		<form method="post">

--- a/locales/English/gamecreate.php
+++ b/locales/English/gamecreate.php
@@ -43,7 +43,7 @@ defined('IN_CODE') or die('This script can not be run by itself.');
 				<br>
 				On webDiplomacy, you can play games against humans or bots. If you want to play against other players,
 				you\'re in the right place. You can just fill out this form. If you want to play against bots,
-				you can click "Play a Game Against Bots." Our bots are artificial intelligence users, so they are not 
+				you can click "Play a game against bots." Our bots are artificial intelligence users, so they are not 
 				computer players like you might encounter in online chess, for example. They are very unique and 
 				they are trained rigorously based on the decisions real players made, which means they are both 
 				intelligent and unpredictable. Give them a try sometime, you might be surprised how good they are!
@@ -76,7 +76,7 @@ defined('IN_CODE') or die('This script can not be run by itself.');
 			setcookie('wD-Tutorial-GameCreate', '', time()-3600);
 		}
 	?>
-	<p><a href="botgamecreate.php">Play A Game Against Bots</a></p>
+	<p><a href="botgamecreate.php">Play a game against bots</a></p>
 
 	<div class = "gameCreateShow">
 		<form method="post">


### PR DESCRIPTION
"Play A Game Against Bots" → "Play a game against bots"
"Play A Game Against Humans" → "Play a game against humans"

It's a link, not a page title or header.