### PR TITLE
Return timesent in api

### DIFF
--- a/api.php
+++ b/api.php
@@ -673,17 +673,18 @@ class SendMessage extends ApiEntry {
 			throw new ClientForbiddenException('User does not have explicit permission to make this API call.');
 		}
 
-		if ($toCountryID < 1 || $toCountryID > count($game->Members) || $toCountryID == $countryID) {
+		if ($toCountryID < 1 || $toCountryID > count($game->Members->ByUserID) || $toCountryID == $countryID) {
 			throw new RequestException('Invalid toCountryID');
 		}
 
 		$toUser = new User($game->Members->ByCountryID[$toCountryID]->userID);
 		if(!$toUser->isCountryMuted($game->id, $countryID)) {
-			libGameMessage::send($toCountryID, $countryID, $message);
+			$time = libGameMessage::send($toCountryID, $countryID, $message);
 		}
 
-		// FIXME: what to return?
-		return json_encode($args);
+		$DB->sql_put("COMMIT");
+		
+		return $time;
 	}
 }
 

--- a/api/responses/game_state.php
+++ b/api/responses/game_state.php
@@ -389,7 +389,7 @@ class GameState {
 		// messages
 		if ($this->pressType != 'NoPress') {
 			$msgTabl = $DB->sql_tabl(
-				"SELECT turn, fromCountryID, toCountryID, message, phaseMarker from wD_GameMessages_Redacted WHERE gameID = ".$this->gameID." AND (fromCountryID = ".$this->countryID." OR toCountryID = ".$this->countryID.") ORDER BY timeSent"
+				"SELECT turn, fromCountryID, toCountryID, message, timeSent, phaseMarker from wD_GameMessages_Redacted WHERE gameID = ".$this->gameID." AND (fromCountryID = ".$this->countryID." OR toCountryID = ".$this->countryID.") ORDER BY timeSent"
 			);
 
 			while ($row = $DB->tabl_hash($msgTabl)) {
@@ -397,6 +397,7 @@ class GameState {
 					$row['message'],
 					$row['fromCountryID'],
 					$row['toCountryID'],
+					$row['timeSent'],
 					$row['phaseMarker']
 				);
 				$phase = $gameSteps->get($row['turn'], 'Diplomacy', array());

--- a/api/responses/message.php
+++ b/api/responses/message.php
@@ -29,6 +29,7 @@ class Message {
 	public $message;
 	public $fromCountryID;
 	public $toCountryID;
+	public $timeSent;
 	public $phaseMarker;
 
 	function toJson() { return json_encode($this); }
@@ -38,14 +39,16 @@ class Message {
 	 * @param string $message - message
 	 * @param int $fromCountryID - sender country ID
 	 * @param int $toCountryID - receiver country ID
+	 * @param int $timeSent - time sent
 	 * @param string $phaseMarker - Diplomacy/Retreat/Builds/etc
 
 	 */
-	function __construct($message, $fromCountryID, $toCountryID, $phaseMarker = null)
+	function __construct($message, $fromCountryID, $toCountryID, $timeSent, $phaseMarker = null)
 	{
 		$this->message = $message;
 		$this->fromCountryID = intval($fromCountryID);
 		$this->toCountryID = intval($toCountryID);
+		$this->timeSent = intval($timeSent);
 		$this->phaseMarker = $phaseMarker;
 	}
 }

--- a/lib/gamemessage.php
+++ b/lib/gamemessage.php
@@ -63,6 +63,8 @@ class libGameMessage
 			throw new Exception(l_t("Message too long"));
 		}
 
+		$time = time();
+
 		$DB->sql_put("INSERT INTO wD_GameMessages
 					(gameID, toCountryID, fromCountryID, turn, message, phaseMarker, timeSent)
 					VALUES(".$Game->id.",
@@ -71,12 +73,14 @@ class libGameMessage
 						".$Game->turn.",
 						'".$message."',
 						'".$Game->phase."',
-						".time().")");
+						".$time.")");
 
 		if ($toCountryID != $fromCountryID || $fromCountryID == 0)
 		{
 			libGameMessage::notify($toCountryID, $fromCountryID);
 		}
+
+		return $time;
 	}
 
 	/**


### PR DESCRIPTION
## What's in this PR

This PR updates how timestamps are passed around for messages. It also adds a missing SQL COMMIT and fixes a `count()` callsite that was causing issues for some reason by following format used at similar callsites elsewhere in the codebase

## How it's tested

Manually.

I have a local instance of webdip running on Apache. I created a game. I then sent messages around between mock accounts I created, and then I confirmed they were received. I used Postman to confirm that message sending API endpoint correctly returns the timestamp.