### PR TITLE
Show votes in game/status

### DIFF
--- a/api/responses/game_state.php
+++ b/api/responses/game_state.php
@@ -24,6 +24,7 @@ use libVariant;
 
 defined('IN_CODE') or die('This script can not be run by itself.');
 require_once(l_r('api/responses/message.php'));
+require_once(l_r('api/responses/vote_message.php'));
 require_once(l_r('api/responses/order.php'));
 require_once(l_r('api/responses/unit.php'));
 
@@ -254,7 +255,7 @@ class GameState {
 		global $DB;
 
 		// Loading game state
-		$gameRow = $DB->sql_hash("SELECT id, variantID, potType, turn, phase, gameOver, pressType FROM wD_Games WHERE id=".$this->gameID);
+		$gameRow = $DB->sql_hash("SELECT id, variantID, potType, turn, phase, gameOver, pressType, drawType, processTime FROM wD_Games WHERE id=".$this->gameID);
 		if ( ! $gameRow )
 			throw new \Exception("Unknown game ID.");
 		$this->variantID = intval($gameRow['variantID']);
@@ -263,11 +264,25 @@ class GameState {
 		$this->phase = $gameRow['phase'];
 		$this->gameOver = $gameRow['gameOver'];
 		$this->pressType = $gameRow['pressType'];
+		$this->drawType=$gameRow['drawType'];
+		$this->processTime=$gameRow['processTime'];
 
 		$memberData = $DB->sql_hash("SELECT countryID, votes, orderStatus, status FROM wD_Members WHERE gameID = ".$this->gameID." AND countryID = ".$this->countryID);
 		$this->votes = $memberData['votes'];
 		$this->orderStatus = $memberData['orderStatus'];
 		$this->status = $memberData['status'];
+
+		// current draw votes
+		$this->publicVotes = [];
+		if ($this->drawType === 'draw-votes-public') {
+			$tabl = $DB->sql_tabl("SELECT countryID, votes FROM wD_Members WHERE gameID = ".$this->gameID);
+			while ($member = $DB->tabl_hash($tabl)) {
+				$countryID = $member["countryID"];
+				$votes = $member["votes"];
+				$this->publicVotes[$countryID] = $votes;
+			}	
+
+		}
 
 		$units = array();
 		$orders = array();
@@ -405,6 +420,37 @@ class GameState {
 				$gameSteps->set($row['turn'], 'Diplomacy', $phase);
 			}
 		}
+
+		// draw vote history
+		if ($this->drawType === 'draw-votes-public') {
+			$messagify_vote = function($vote) {
+				return ["Voted for ".$vote, "Un-Voted for ".$vote];
+			};
+			
+			$msgs = array_merge(...array_map($messagify_vote, \Members::$votes));
+
+			$msgTabl = $DB->sql_tabl(
+				"SELECT turn, fromCountryID, toCountryID, message, timeSent, phaseMarker 
+				from wD_GameMessages_Redacted 
+				WHERE gameID = ".$this->gameID." AND 
+				fromCountryID = toCountryID 
+				AND message in ('".implode("','",$msgs)."')
+				ORDER BY timeSent"
+			);
+
+			while ($row = $DB->tabl_hash($msgTabl)) {
+				$message = new \webdiplomacy_api\VoteMessage(
+					$row['message'],
+					$row['fromCountryID'],
+					$row['timeSent'],
+					$row['phaseMarker']
+				);
+				$phase = $gameSteps->get($row['turn'], 'Diplomacy', array());
+				$phase['publicVotesHistory'][] = $message;
+				$gameSteps->set($row['turn'], 'Diplomacy', $phase);
+			}
+		}
+
 		foreach ($gameSteps->toArray() as $step) {
 			list($turn, $phaseName, $data) = $step;
 			$centerTurn = $turn;

--- a/api/responses/vote_message.php
+++ b/api/responses/vote_message.php
@@ -1,0 +1,50 @@
+<?php
+/*
+    Copyright (C) 2004-2010 Kestas J. Kuliukas / Timothy Jones
+
+	This file is part of webDiplomacy.
+
+    webDiplomacy is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    webDiplomacy is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with webDiplomacy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace webdiplomacy_api;
+
+defined('IN_CODE') or die('This script can not be run by itself.');
+
+/**
+ * A vote, along with the sender country ID.
+ * @package webdiplomacy_api
+ */
+class VoteMessage {
+	public $vote;
+	public $countryID;
+	public $timeSent;
+	public $phaseMarker;
+
+	function toJson() { return json_encode($this); }
+
+	/**
+	 * @param string $vote - e.g. 'Draw','Pause','Cancel','Concede'
+	 * @param int $countryID - sender country ID
+	 * @param int $timeSent - time sent
+	 * @param string $phaseMarker - Diplomacy/Retreat/Builds/etc
+
+	 */
+	function __construct($vote, $countryID, $timeSent, $phaseMarker = null)
+	{
+		$this->vote = $vote;
+		$this->countryID = intval($countryID);
+		$this->timeSent = intval($timeSent);
+		$this->phaseMarker = $phaseMarker;
+	}
+}


### PR DESCRIPTION
# What's in this PR?

In games with public draw votes, it would be nice if the API endpoint `game/status` returns the current votes of other players. To this end, I add a field `publicVotes` that is empty when draw votes are hidden and otherwise maps country IDs to vote statuses. Additionally, let's return the draw type for the game  (`drawType` in `wD_Games`) and the time until the next phase (`processTime` in `wD_Games`).

Secondly, it would also be nice to surface vote history with timestamps (in public draw vote games). When a player submits a draw vote themself, they can see a message "Voted for Draw" in their personal message history, along with a timestamp. I should also be able to see something similar for other players' votes:

```
"phases": [ 
            ...,
            {
            ...,
            "publicVotesHistory": [
                            {
                                "vote": "Voted for Draw",
                                "countryID": 5,
                                "timeSent": 1647212107,
                                "phaseMarker": "Diplomacy"
                            },
                            {
                                "vote": "Un-Voted for Cancel",
                                "countryID": 5,
                                "timeSent": 1647212399,
                                "phaseMarker": "Diplomacy"
                            },
                            ...
            ]}
```


# How is it tested?

I created a game on a local server with public draw votes turned on. I then sent a variety of votes for different players (e.g. "Draw", "Pause") and confirmed the status json for another player shows these:

<img width="496" alt="Screen Shot 2022-03-08 at 11 55 20 AM" src="https://user-images.githubusercontent.com/37087066/157286758-b943d5d1-3ddb-4ab5-a082-8e31b82f4afb.png">

Secondly, I created a game with hidden draw votes. I sent a variety of votes for different players, and confirmed that these did not surface in another player's status:

<img width="306" alt="Screen Shot 2022-03-08 at 11 54 30 AM" src="https://user-images.githubusercontent.com/37087066/157286580-36bfb127-90c2-42a1-ad95-e6924e9278f0.png">

I also confirmed that vote messages render correctly in the API (see json snippet in "What's in this PR?" section).

