### PR TITLE
Log API votes in message history

### DIFF
--- a/api.php
+++ b/api.php
@@ -319,6 +319,12 @@ class ToggleVote extends ApiEntry {
 		$game = 
 		$currentVotes = $DB->sql_hash("SELECT votes FROM wD_Members WHERE gameID = ".$gameID." AND countryID = ".$countryID." AND userID = ".$userID);
 		$currentVotes = $currentVotes['votes'];
+
+		// Keep a log that a vote was set in the game messages, so the vote time is recorded
+		require_once(l_r('lib/gamemessage.php'));
+		$voteOn = in_array($vote, explode(',',$currentVotes));
+		libGameMessage::send($countryID, $countryID, ($voteOn?'Un-':'').'Voted for '.$vote, $gameID);
+
 		$newVotes = '';
 		if( strpos($currentVotes, $vote) !== false )
 		{


### PR DESCRIPTION
## Description

We currently log votes sent in the web UI to the message history to keep track of when people called for different kinds of votes (https://github.com/kestasjk/webDiplomacy/blob/master/board/member.php#L142-L144). This can sometimes be useful context when discussing previous draw attempts. 

However, we do not do such vote logging by message history for votes sent by API. Let's fix that

## Testing

Manually