### PR TITLE
Include global messages in API game/status

### DIFF
--- a/api/responses/game_state.php
+++ b/api/responses/game_state.php
@@ -404,7 +404,12 @@ class GameState {
 		// messages
 		if ($this->pressType != 'NoPress') {
 			$msgTabl = $DB->sql_tabl(
-				"SELECT turn, fromCountryID, toCountryID, message, timeSent, phaseMarker from wD_GameMessages_Redacted WHERE gameID = ".$this->gameID." AND (fromCountryID = ".$this->countryID." OR toCountryID = ".$this->countryID.") ORDER BY timeSent"
+				"SELECT turn, fromCountryID, toCountryID, message, timeSent, phaseMarker
+				FROM wD_GameMessages_Redacted
+				WHERE gameID = ".$this->gameID. 
+				" AND (fromCountryID = ".$this->countryID." OR toCountryID = ".$this->countryID.
+				" OR toCountryID = 0)
+				ORDER BY timeSent"
 			);
 
 			while ($row = $DB->tabl_hash($msgTabl)) {
@@ -431,7 +436,7 @@ class GameState {
 
 			$msgTabl = $DB->sql_tabl(
 				"SELECT turn, fromCountryID, toCountryID, message, timeSent, phaseMarker 
-				from wD_GameMessages_Redacted 
+				FROM wD_GameMessages_Redacted
 				WHERE gameID = ".$this->gameID." AND 
 				fromCountryID = toCountryID 
 				AND message in ('".implode("','",$msgs)."')


### PR DESCRIPTION
## Description

Currently, the API endpoint `game/status`, which info about game state such as message history, does not surface messages send to the global messaging channel. Let's fix this.

## Testing

Manually.