### PR TITLE
Cold War games forced to unranked 5pt bets

### DIFF
--- a/gamecreate.php
+++ b/gamecreate.php
@@ -133,7 +133,7 @@ if( isset($_REQUEST['newGame']) and is_array($_REQUEST['newGame']) )
 		$input['anon'] = ( (strtolower($input['anon']) == 'yes') ? 'Yes' : 'No' );
 		
 		// Force 1 vs 1 variants to be unranked to prevent point farming. 
-		if ( $input['variantID'] == 15 or  $input['variantID'] == 23)
+		if ( $input['variantID'] == 15 or  $input['variantID'] == 23 or $input['variantID'] == 91)
 		{
 			$input['bet'] = 5; 
 			$input['potType'] = 'Unranked';


### PR DESCRIPTION
This adds Cold War to the Game Creation page's code that forces 1v1s to only create unranked, 5pt bet game, to prevent point farming. 
I had forgotten to add this when first adding the Cold War files.