### PR TITLE
Fix format of phase finished message

### DIFF
--- a/beta-src/src/components/ui/WDGameProgressOverlay.tsx
+++ b/beta-src/src/components/ui/WDGameProgressOverlay.tsx
@@ -88,7 +88,7 @@ const WDGameProgressOverlay: React.FC<WDGameProgressOverlayProps> = function ({
         const psy = getHistoricalPhaseSeasonYear(status, idx);
         stuffToRender.push(
           <Box key={`progressBox${idx}`} sx={{ m: "4px" }}>
-            Finished phase ${formatPSYForDisplay(psy)}.
+            Finished phase {formatPSYForDisplay(psy)}.
           </Box>,
         );
       }


### PR DESCRIPTION
The phase finished message in the new UI incorrectly says "Finished phase $Winter 1905 Builds." This PR makes it correctly say "Finished phase Winter 1905 Builds."