### PR TITLE
Add links for beta spectation

### DIFF
--- a/gamepanel/game.php
+++ b/gamepanel/game.php
@@ -154,12 +154,12 @@ class panelGame extends Game
 	{
 		global $User;
 
-		if (!$this->Members->isJoined()) {
-			return null;
-		}
-
 		if ($User->isActiveBeta && $this->isClassicGame()) {
-			return'<a href="beta?gameID='.$this->id.'" >'.l_t('Play Beta').'</a> ';
+			if ($this->Members->isJoined()) {
+				return '<a href="beta?gameID='.$this->id.'" >'.l_t('Play Beta').'</a> ';
+			} else {
+				return '<a href="beta?gameID='.$this->id.'" >'.l_t('View Beta').'</a> ';
+			}
 		};
 
 		return null;

--- a/gamepanel/gamehome.php
+++ b/gamepanel/gamehome.php
@@ -169,11 +169,13 @@ class panelGameHome extends panelGameBoard
 
 		if ($this->watched() || $userInGame == 0)
 		{
+			if ($User->isActiveBeta && $this->isClassicGame()) { $playBeta = '- <a href="beta?gameID='.$this->id.'" >'.l_t('View Beta').'</a> '; }
 			if ($this->watched()) { $watchString = '- <a href="board.php?gameID='.$this->id.'&unwatch">'.l_t('Stop spectating').'</a>'; }
 			if( $this->phase == 'Pre-game')
 			{
 				return '<div class="bar homeGameLinks barAlt'.libHTML::alternate().'">
 					<a href="board.php?gameID='.$this->id.'">'.l_t('Open').'</a>
+					'.$playBeta.'
 					'.$watchString.'
 					</div>';
 			}
@@ -181,6 +183,7 @@ class panelGameHome extends panelGameBoard
 			{
 				return '<div class="bar homeGameLinks barAlt'.libHTML::alternate().'">
 					<a href="board.php?gameID='.$this->id.'#gamePanel">'.l_t('Open').'</a> 
+					'.$playBeta.'
 					'.$watchString.'
 					</div>';
 			}


### PR DESCRIPTION
Even though spectation was possible in the beta UI, there were no links to make it obvious how to do it. Added the links.

<img width="456" alt="image" src="https://user-images.githubusercontent.com/5702157/182286094-dbe5da72-7caf-46a8-811b-d91797feebed.png">

<img width="322" alt="image" src="https://user-images.githubusercontent.com/5702157/182286111-48206f79-6b23-4349-856e-6562e0df7a63.png">
